### PR TITLE
[#13] Integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+
+go:
+  - "1.11.x"
+  - master
+
+env:
+  - DEP_VERSION=0.5.0
+  - NODE_TEST_IMAGE_VERSION=10.15.0
+
+services:
+  - docker
+
+before_install:
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
+
+  - docker pull node:${NODE_TEST_IMAGE_VERSION}
+
+install:
+  - dep ensure
+
+script: go test -v ./...


### PR DESCRIPTION
Add `.travis.yml` with 
* Golang support for `1.11.x` and `master` version.
* lint validation using `travis lint`. [[ref](https://github.com/travis-ci/travis.rb#lint)]