### PR TITLE
Resolve travis build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ go:
   - master
 
 env:
-  - DEP_VERSION=0.5.0
-  - NODE_TEST_IMAGE_VERSION=10.15.0
+  global:
+    - DEP_VERSION="0.5.0"
+    - NODE_TEST_IMAGE_VERSION="10.15.0"
 
 services:
   - docker
@@ -18,6 +19,6 @@ before_install:
   - docker pull node:${NODE_TEST_IMAGE_VERSION}
 
 install:
-  - dep ensure
+  - dep ensure -v
 
 script: go test -v ./...


### PR DESCRIPTION
Define environment variables as `global` and storing versions as strings.