### PR TITLE
Asynchronous containerisation, add support for global configuration and cli flags

### DIFF
--- a/.dunner.yaml
+++ b/.dunner.yaml
@@ -1,5 +1,11 @@
 build:
-    - image: node
-      command: ["node", "--version"]
-    - image: node
-      command: ["npm", "--version"]
+  - image: node
+    command: ["node", "--version"]
+  - image: node
+    command: ["npm", "--version"]
+  - image: node:10.15.0
+    command: ["node", "--version"]
+  - image: node:10.15.0
+    command: ["npm", "--version"]
+  - image: alpine
+    command: ["apk", "update"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,12 +98,39 @@
   version = "v0.3.3"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:701239373bbf22998c5a36c76d2ff4ee309b3980e39b7a66d72cabd3aab748fa"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
   pruneopts = "UT"
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
   version = "v0.4"
+
+[[projects]]
+  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "UT"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -120,6 +147,22 @@
   pruneopts = "UT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
@@ -141,6 +184,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -157,6 +208,25 @@
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:3e39bafd6c2f4bf3c76c3bfd16a2e09e016510ad5db90dc02b88e2f565d6d595"
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = "UT"
+  revision = "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5"
+  version = "v1.2.1"
+
+[[projects]]
+  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
   name = "github.com/spf13/cobra"
   packages = ["."]
@@ -165,12 +235,28 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "UT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:de37e343c64582d7026bf8ab6ac5b22a72eac54f3a57020db31524affed9f423"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
@@ -205,6 +291,21 @@
   revision = "b05ddf57801d2239d6ab0ee35f9d981e0420f4ac"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm",
+  ]
+  pruneopts = "UT"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -225,6 +326,7 @@
     "github.com/docker/docker/pkg/term",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
+    "github.com/spf13/viper",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -3,10 +3,18 @@ package cmd
 import (
 	"github.com/leopardslab/Dunner/pkg/dunner"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
 	rootCmd.AddCommand(doCmd)
+
+	// Async Mode
+	doCmd.Flags().BoolP("async", "A", false, "Async mode")
+	if err := viper.BindPFlag("Async", doCmd.Flags().Lookup("async")); err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 var doCmd = &cobra.Command{

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -5,11 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type Config struct {
-	Image   string    `yaml:"image"`
-	Command [] string `yaml:"command"`
-}
-
 func init() {
 	rootCmd.AddCommand(doCmd)
 }

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -18,8 +18,9 @@ func init() {
 }
 
 var doCmd = &cobra.Command{
-	Use:   "do",
+	Use:   "do [taskName]",
 	Short: "Do whatever you say",
 	Long:  `You can run any task defined on the '.dunner.yaml' with this command`,
 	Run:   dunner.Do,
+	Args:  cobra.ExactArgs(1),
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	docker "docker.io/go-docker"
 	"github.com/leopardslab/Dunner/internal/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var log = logger.Log
@@ -24,6 +25,25 @@ var rootCmd = &cobra.Command{
 
 		fmt.Println("Dunner running!")
 	},
+}
+
+func init() {
+
+	// Verbose Mode
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose mode")
+	if err := viper.BindPFlag("Verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Dunner task file
+	rootCmd.PersistentFlags().StringP("task-file", "t", ".dunner.yaml", "Task file to be run")
+	if err := rootCmd.MarkPersistentFlagFilename("task-file", "yaml", "yml"); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlag("DunnerTaskFile", rootCmd.PersistentFlags().Lookup("task-file")); err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 // Execute method executes the 'Run' method of rootCmd.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,18 +1,19 @@
 package cmd
 
 import (
-	"docker.io/go-docker"
 	"fmt"
+	"os"
+
+	docker "docker.io/go-docker"
 	"github.com/leopardslab/Dunner/internal/logger"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var log = logger.Log
 
 var rootCmd = &cobra.Command{
 	Use:   "dunner",
-	Short: "Dunner is a Docker based task runner",
+	Short: "Dunner is a Docker based task-runner",
 	Long:  `You can define a set of commands and on what Docker images these commands should run as steps. A task has many steps. Then you can run these tasks with 'dunner do nameoftask'`,
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -25,6 +26,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+// Execute method executes the 'Run' method of rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,16 +1,18 @@
 package logger
 
-import(
-	"github.com/sirupsen/logrus"
+import (
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
+// Log is a globally configured logger
 var Log = logrus.New()
 
 func init() {
-	Log.Formatter = new(logrus.TextFormatter)					// default
-	Log.Formatter.(*logrus.TextFormatter).FullTimestamp = true	// Enable timestamp
-	Log.Formatter.(*logrus.TextFormatter).TimestampFormat = "2006-01-02 15:04:05"	// Customize timestamp format
+	Log.Formatter = new(logrus.TextFormatter)                                     // Default
+	Log.Formatter.(*logrus.TextFormatter).FullTimestamp = true                    // Enable timestamp
+	Log.Formatter.(*logrus.TextFormatter).TimestampFormat = "2006-01-02 15:04:05" // Customize timestamp format
 	Log.Level = logrus.TraceLevel
 	Log.Out = os.Stdout
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,0 +1,29 @@
+package settings
+
+import (
+	"github.com/spf13/viper"
+)
+
+// Initialize sets default configuration for the project
+func Initialize() {
+	// Settings file
+	viper.SetConfigName("settings")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath("../../")
+	viper.AddConfigPath("$HOME/.dunner/")
+	viper.AddConfigPath("/etc/dunner/")
+	// TODO Add standard configuration paths for Windows OS
+
+	// Automatic binding of environment variables
+	viper.SetEnvPrefix("dunner")
+	viper.AutomaticEnv()
+
+	// Files
+	viper.SetDefault("DunnerTaskFile", ".dunner.yaml")
+	viper.SetDefault("GlobalLogFile", "/var/log/dunner/logs/")
+	viper.SetDefault("LocalLogFile", nil)
+
+	// Modes
+	viper.SetDefault("Async", false)
+	viper.SetDefault("Verbose", false)
+}

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"github.com/leopardslab/Dunner/cmd"
+	"github.com/leopardslab/Dunner/internal/settings"
 )
 
 func main() {
+	settings.Initialize()
 	cmd.Execute()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,3 +31,19 @@ func GetConfigs(filename string) (*Configs, error) {
 
 	return &configs, nil
 }
+
+func (c *Configs) GetAllImages() ([] string, error) {
+	var images []string
+	var set = make(map[string]bool)
+
+	for _, tasks := range c.Tasks {
+		for _, task := range tasks {
+			set[task.Image] = true
+		}
+	}
+
+	for img := range set {
+		images = append(images, img)
+	}
+	return images, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,23 +1,27 @@
 package config
 
 import (
-	"github.com/leopardslab/Dunner/internal/logger"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"github.com/leopardslab/Dunner/internal/logger"
+	yaml "gopkg.in/yaml.v2"
 )
 
 var log = logger.Log
 
+// Task describes a single task to be run in a docker container
 type Task struct {
-	Name    string    `yaml:"name"`
-	Image   string    `yaml:"image"`
-	Command [] string `yaml:"command"`
+	Name    string   `yaml:"name"`
+	Image   string   `yaml:"image"`
+	Command []string `yaml:"command"`
 }
 
+// Configs describes the parsed information from the dunner file
 type Configs struct {
 	Tasks map[string][]Task
 }
 
+// GetConfigs reads and parses tasks from the dunner file
 func GetConfigs(filename string) (*Configs, error) {
 	fileContents, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -32,7 +36,8 @@ func GetConfigs(filename string) (*Configs, error) {
 	return &configs, nil
 }
 
-func (c *Configs) GetAllImages() ([] string, error) {
+// GetAllImages extracts a set of images required for all the tasks to run
+func (c *Configs) GetAllImages() ([]string, error) {
 	var images []string
 	var set = make(map[string]bool)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,6 +45,11 @@ func TestGetConfigs(t *testing.T) {
 		Tasks: tasks,
 	}
 
+	imgs, _ := expected.GetAllImages()
+	if !reflect.DeepEqual([]string{task.Image}, imgs) {
+		t.Fatalf("Images list not equal to expected")
+	}
+
 	if !reflect.DeepEqual(expected, *pout) {
 		t.Fatalf("Output not equal to expected")
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -2,34 +2,37 @@ package docker
 
 import (
 	"context"
-	"docker.io/go-docker"
-	"docker.io/go-docker/api/types"
-	"docker.io/go-docker/api/types/container"
-	"docker.io/go-docker/api/types/mount"
-	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/pkg/term"
-	"github.com/leopardslab/Dunner/internal/logger"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	docker "docker.io/go-docker"
+	"docker.io/go-docker/api/types"
+	"docker.io/go-docker/api/types/container"
+	"docker.io/go-docker/api/types/mount"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
+	"github.com/leopardslab/Dunner/internal/logger"
 )
 
 var log = logger.Log
 
+// Step describes the information required to run one task in docker container
 type Step struct {
 	Task    string
 	Name    string
 	Image   string
-	Command [] string
+	Command []string
 	Env     map[string]string
 	WorkDir string
 	Volumes map[string]string
 }
 
-func (step Step) Do() (*io.ReadCloser, error) {
+// Exec method is used to execute the task described in the corresponding step
+func (step Step) Exec() (*io.ReadCloser, error) {
 
 	var (
 		hostMountFilepath   = "./"
@@ -69,13 +72,13 @@ func (step Step) Do() (*io.ReadCloser, error) {
 		log.Fatal(err)
 	}
 
-	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+	if err = cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
 		log.Fatal(err)
 	}
 
 	statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
 	select {
-	case err := <-errCh:
+	case err = <-errCh:
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -95,6 +98,7 @@ func (step Step) Do() (*io.ReadCloser, error) {
 
 }
 
+// PullImages pulls images asynchronously from the hub if not present on the host
 func PullImages(images *[]string) error {
 
 	ctx := context.Background()
@@ -111,7 +115,7 @@ func PullImages(images *[]string) error {
 		go func(image string) {
 
 			defer wg.Done()
-			log.Infof("Pulling image '%s'", image)
+			log.Infof("Pulling an image: '%s'", image)
 
 			out, err := cli.ImagePull(ctx, image, types.ImagePullOptions{})
 			if err != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/leopardslab/Dunner/internal/logger"
+	"github.com/spf13/viper"
 )
 
 var log = logger.Log
@@ -57,7 +58,7 @@ func (step Step) Exec() (*io.ReadCloser, error) {
 	}
 
 	termFd, isTerm := term.GetFdInfo(os.Stdout)
-	const verbose = false
+	var verbose = viper.GetBool("Verbose")
 	if verbose {
 		if err = jsonmessage.DisplayJSONMessagesStream(out, os.Stdout, termFd, isTerm, nil); err != nil {
 			log.Fatal(err)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -10,9 +10,11 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/leopardslab/Dunner/internal/logger"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 var log = logger.Log
@@ -38,18 +40,6 @@ func (step Step) Do() (*io.ReadCloser, error) {
 	ctx := context.Background()
 	cli, err := docker.NewEnvClient()
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	out, err := cli.ImagePull(ctx, step.Image, types.ImagePullOptions{})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	defer out.Close()
-
-	termFd, isTerm := term.GetFdInfo(os.Stdout)
-	if err = jsonmessage.DisplayJSONMessagesStream(out, os.Stdout, termFd, isTerm, nil); err != nil {
 		log.Fatal(err)
 	}
 
@@ -92,7 +82,7 @@ func (step Step) Do() (*io.ReadCloser, error) {
 	case <-statusCh:
 	}
 
-	out, err = cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{
+	out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 	})
@@ -103,4 +93,43 @@ func (step Step) Do() (*io.ReadCloser, error) {
 	log.Infof("Running task '%+v' on '%+v' Docker with command '%+v'", step.Task, step.Image, strings.Join(step.Command, " "))
 	return &out, nil
 
+}
+
+func PullImages(images *[]string) error {
+
+	ctx := context.Background()
+	cli, err := docker.NewEnvClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	for _, image := range *images {
+		wg.Add(1)
+
+		go func(image string) {
+
+			defer wg.Done()
+			log.Infof("Pulling image '%s'", image)
+
+			out, err := cli.ImagePull(ctx, image, types.ImagePullOptions{})
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			termFd, isTerm := term.GetFdInfo(os.Stdout)
+			if err = jsonmessage.DisplayJSONMessagesStream(out, ioutil.Discard, termFd, isTerm, nil); err != nil {
+				log.Fatal(err)
+			}
+
+			if err = out.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}(image)
+	}
+	wg.Wait()
+	log.Info("Pull complete\n\n")
+
+	return nil
 }

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -24,7 +24,7 @@ func TestStep_Do(t *testing.T) {
 		t.Error(err)
 	}
 
-	pout, err := step.Do()
+	pout, err := step.Exec()
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestStep_Do(t *testing.T) {
 
-	var testNodeVersion= "10.15.0"
+	var testNodeVersion = "10.15.0"
 
 	step := &Step{
 		Task:    "test",
@@ -18,6 +18,10 @@ func TestStep_Do(t *testing.T) {
 		Env:     nil,
 		WorkDir: "test",
 		Volumes: nil,
+	}
+	images := []string{step.Image}
+	if err := PullImages(&images); err != nil {
+		t.Error(err)
 	}
 
 	pout, err := step.Do()
@@ -35,5 +39,4 @@ func TestStep_Do(t *testing.T) {
 	if result != testNodeVersion {
 		t.Fatalf("Detected version of node container: '%s'; Expected output: '%s'", result, testNodeVersion)
 	}
-
 }

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -19,10 +19,6 @@ func TestStep_Do(t *testing.T) {
 		WorkDir: "test",
 		Volumes: nil,
 	}
-	images := []string{step.Image}
-	if err := PullImages(&images); err != nil {
-		t.Error(err)
-	}
 
 	pout, err := step.Exec()
 	if err != nil {

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -1,19 +1,22 @@
 package dunner
 
 import (
+	"os"
+
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/leopardslab/Dunner/internal/logger"
 	"github.com/leopardslab/Dunner/pkg/config"
 	"github.com/leopardslab/Dunner/pkg/docker"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var log = logger.Log
 
+// Do method is invoked for command-line use
 func Do(_ *cobra.Command, args []string) {
 
-	// TODO Should get the name of the Dunner file from a constant or an environment variable or config file
+	// TODO Should get the name of the Dunner file
+	// from a constant or an environment variable or config file
 	var dunnerFile = ".dunner.yaml"
 
 	configs, err := config.GetConfigs(dunnerFile)
@@ -33,7 +36,7 @@ func Do(_ *cobra.Command, args []string) {
 			Image:   stepDefinition.Image,
 			Command: stepDefinition.Command,
 		}
-		pout, err := step.Do()
+		pout, err := step.Exec()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -2,6 +2,8 @@ package dunner
 
 import (
 	"os"
+	"strings"
+	"sync"
 
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/leopardslab/Dunner/internal/logger"
@@ -14,6 +16,7 @@ var log = logger.Log
 
 // Do method is invoked for command-line use
 func Do(_ *cobra.Command, args []string) {
+	const async = false
 
 	// TODO Should get the name of the Dunner file
 	// from a constant or an environment variable or config file
@@ -24,31 +27,50 @@ func Do(_ *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	images, err := configs.GetAllImages()
-	if err = docker.PullImages(&images); err != nil {
-		log.Fatal(err)
-	}
-
+	var wg sync.WaitGroup
 	for _, stepDefinition := range configs.Tasks[args[0]] {
+		if async {
+			wg.Add(1)
+		}
 		step := docker.Step{
 			Task:    args[0],
 			Name:    stepDefinition.Name,
 			Image:   stepDefinition.Image,
 			Command: stepDefinition.Command,
 		}
-		pout, err := step.Exec()
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, *pout)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if err = (*pout).Close(); err != nil {
-			log.Fatal(err)
+		if async {
+			go process(&step, &wg)
+		} else {
+			process(&step, &wg)
 		}
 	}
 
+	wg.Wait()
+}
+
+func process(s *docker.Step, wg *sync.WaitGroup) {
+	const async = false
+	if async {
+		defer wg.Done()
+	}
+
+	pout, err := (*s).Exec()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Infof(
+		"Running task '%+v' on '%+v' Docker with command '%+v'",
+		s.Task,
+		s.Image,
+		strings.Join(s.Command, " "),
+	)
+
+	if _, err = stdcopy.StdCopy(os.Stdout, os.Stderr, *pout); err != nil {
+		log.Fatal(err)
+	}
+
+	if err = (*pout).Close(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -19,6 +19,11 @@ var log = logger.Log
 func Do(_ *cobra.Command, args []string) {
 	var async = viper.GetBool("Async")
 
+	if verbose := viper.GetBool("Verbose"); async && verbose {
+		log.Warn("Silencing verbose in asynchronous mode")
+		viper.Set("Verbose", false)
+	}
+
 	var dunnerFile = viper.GetString("DunnerTaskFile")
 
 	configs, err := config.GetConfigs(dunnerFile)

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -21,6 +21,11 @@ func Do(_ *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	images, err := configs.GetAllImages()
+	if err = docker.PullImages(&images); err != nil {
+		log.Fatal(err)
+	}
+
 	for _, stepDefinition := range configs.Tasks[args[0]] {
 		step := docker.Step{
 			Task:    args[0],

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -10,17 +10,16 @@ import (
 	"github.com/leopardslab/Dunner/pkg/config"
 	"github.com/leopardslab/Dunner/pkg/docker"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var log = logger.Log
 
 // Do method is invoked for command-line use
 func Do(_ *cobra.Command, args []string) {
-	const async = false
+	var async = viper.GetBool("Async")
 
-	// TODO Should get the name of the Dunner file
-	// from a constant or an environment variable or config file
-	var dunnerFile = ".dunner.yaml"
+	var dunnerFile = viper.GetString("DunnerTaskFile")
 
 	configs, err := config.GetConfigs(dunnerFile)
 	if err != nil {
@@ -49,7 +48,7 @@ func Do(_ *cobra.Command, args []string) {
 }
 
 func process(s *docker.Step, wg *sync.WaitGroup) {
-	const async = false
+	var async = viper.GetBool("Async")
 	if async {
 		defer wg.Done()
 	}


### PR DESCRIPTION

This PR makes Dunner a _complete_ cli tool, which means that now the tool will have the ability to read configuration from host environment variables and has flags that can be used to control/override those configurations.
* Support for async mode where image pull as well as containerisation are concurrent.
* Add support for verbose mode.
* Support for global configuration for the project using viper.
* Add flags and bind viper configuration with them.
	Supported flags:
	* `--verbose` or `-v` :  Verbose mode
	* `--async` or `-A` :  Asynchronous mode
	* `--task-file` or `-t` `path/to/taskfile` : Task file 

__Help page for `root` command__ 
```
➜  Dunner git:(async-containerisation) ./dunner --help
You can define a set of commands and on what Docker images these commands should run as steps. A task has many steps. Then you can run these tasks with 'dunner do nameoftask'

Usage:
  dunner [flags]
  dunner [command]

Available Commands:
  do          Do whatever you say
  help        Help about any command
  version     Print the version number of Dunner

Flags:
  -h, --help               help for dunner
  -t, --task-file string   Task file to be run (default ".dunner.yaml")
  -v, --verbose            Verbose mode

Use "dunner [command] --help" for more information about a command.
```
__Help page for `do` command__
```
➜  Dunner git:(async-containerisation) ./dunner do --help
You can run any task defined on the '.dunner.yaml' with this command

Usage:
  dunner do [taskName] [flags]

Flags:
  -A, --async   Async mode
  -h, --help    help for do

Global Flags:
  -t, --task-file string   Task file to be run (default ".dunner.yaml")
  -v, --verbose            Verbose mode
```