### PR TITLE
Optimize dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,32 +2,6 @@
 
 
 [[projects]]
-  digest = "1:8c08dabeec001da3389028236a924397b9e11d4c519439d0135db44f9f21cb0f"
-  name = "docker.io/go-docker"
-  packages = [
-    ".",
-    "api",
-    "api/types",
-    "api/types/blkiodev",
-    "api/types/container",
-    "api/types/events",
-    "api/types/filters",
-    "api/types/image",
-    "api/types/mount",
-    "api/types/network",
-    "api/types/registry",
-    "api/types/strslice",
-    "api/types/swarm",
-    "api/types/swarm/runtime",
-    "api/types/time",
-    "api/types/versions",
-    "api/types/volume",
-  ]
-  pruneopts = "UT"
-  revision = "b3f5b5de7bbce0acc6a7fc0a4c2b88db678e262e"
-  version = "v1.0.0"
-
-[[projects]]
   branch = "master"
   digest = "1:6da51e5ec493ad2b44cb04129e2d0a068c8fb9bd6cb5739d199573558696bb94"
   name = "github.com/Azure/go-ansiterm"
@@ -66,9 +40,27 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a2a7b6b4af8ed07209d72648405e66cadd24e10633eb79916abd219f334d1bd8"
+  digest = "1:3c9913ecae011df5973403b3522bcc47593b312d32595a376fb361c7408d946b"
   name = "github.com/docker/docker"
   packages = [
+    "api",
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/image",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "errdefs",
     "pkg/jsonmessage",
     "pkg/stdcopy",
     "pkg/term",
@@ -268,11 +260,9 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3866deb325971ae774d5844b70f058923b7757cd2eec6db2bd6d028143f6b65f"
+  digest = "1:3fa70ba3ba75f47646d2a6ff518f46f3c4a215912eb6f9c26b6e956918038f01"
   name = "golang.org/x/net"
   packages = [
-    "context",
-    "context/ctxhttp",
     "internal/socks",
     "proxy",
   ]
@@ -317,10 +307,10 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "docker.io/go-docker",
-    "docker.io/go-docker/api/types",
-    "docker.io/go-docker/api/types/container",
-    "docker.io/go-docker/api/types/mount",
+    "github.com/docker/docker/api/types",
+    "github.com/docker/docker/api/types/container",
+    "github.com/docker/docker/api/types/mount",
+    "github.com/docker/docker/client",
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/stdcopy",
     "github.com/docker/docker/pkg/term",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,12 +26,12 @@
 
 
 [[constraint]]
-  name = "docker.io/go-docker"
-  version = "1.0.0"
-
-[[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
+
+[[constraint]]
+  name = "github.com/spf13/viper"
+  version = "1.3.1"
 
 [[override]]
   name = "github.com/Nvveen/Gotty"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	docker "docker.io/go-docker"
+	"github.com/docker/docker/client"
 	"github.com/leopardslab/Dunner/internal/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -18,7 +18,10 @@ var rootCmd = &cobra.Command{
 	Long:  `You can define a set of commands and on what Docker images these commands should run as steps. A task has many steps. Then you can run these tasks with 'dunner do nameoftask'`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		_, err := docker.NewEnvClient()
+		_, err := client.NewClientWithOpts(
+			client.FromEnv,
+			client.WithVersion(viper.GetString("DockerAPIVersion")),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -4,8 +4,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Initialize sets default configuration for the project
-func Initialize() {
+func init() {
 	// Settings file
 	viper.SetConfigName("settings")
 	viper.SetConfigType("yaml")
@@ -26,4 +25,7 @@ func Initialize() {
 	// Modes
 	viper.SetDefault("Async", false)
 	viper.SetDefault("Verbose", false)
+
+	// Constants
+	viper.SetDefault("DockerAPIVersion", "1.39")
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"github.com/leopardslab/Dunner/cmd"
-	"github.com/leopardslab/Dunner/internal/settings"
 )
 
 func main() {
-	settings.Initialize()
 	cmd.Execute()
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	docker "docker.io/go-docker"
-	"docker.io/go-docker/api/types"
-	"docker.io/go-docker/api/types/container"
-	"docker.io/go-docker/api/types/mount"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/leopardslab/Dunner/internal/logger"
@@ -40,7 +40,10 @@ func (step Step) Exec() (*io.ReadCloser, error) {
 	)
 
 	ctx := context.Background()
-	cli, err := docker.NewEnvClient()
+	cli, err := client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithVersion(viper.GetString("DockerAPIVersion")),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Currently, the source dependency for docker client is [go-docker](https://github.com/docker/go-docker), which has been inactive for almost two years. Also, the actual code for the latest docker service has its source code in the [moby](https://github.com/moby/moby) project, aliased as [`docker/docker`](https://github.com/docker/docker). Also, some of the functionalities except for client are already implemented using `docker/docker`, rather than `docker.io/go-docker`, therefore, `dep` 'ensures' that both the projects are present in the `vendor` directory. To optimize the dependencies, as well as to add support of latest functionalities of docker all the time, this PR completely removes `go-docker`, and instantiate client from the `docker/docker` repository.