### PR TITLE
Environment variables for containers

### DIFF
--- a/.dunner.yaml
+++ b/.dunner.yaml
@@ -12,5 +12,6 @@ build:
   - image: alpine
     command: ["printenv"]
     envs:
-      - MYVAR=121
-      - MYVAR2=dunner
+      - PERM=775
+      - ID=dunner
+      - DIR=`$HOME`

--- a/.dunner.yaml
+++ b/.dunner.yaml
@@ -9,3 +9,8 @@ build:
     command: ["npm", "--version"]
   - image: alpine
     command: ["apk", "update"]
+  - image: alpine
+    command: ["printenv"]
+    envs:
+      - MYVAR=121
+      - MYVAR2=dunner

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 /Godeps/
 
 # End of https://www.gitignore.io/api/go
+
+# Environment file
+.env

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,6 +133,14 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:ecd9aa82687cf31d1585d4ac61d0ba180e42e8a6182b85bd785fcca8dfeefc1b"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -314,6 +322,7 @@
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/stdcopy",
     "github.com/docker/docker/pkg/term",
+    "github.com/joho/godotenv",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,15 @@ func init() {
 		log.Fatal(err)
 	}
 
+	// Environment file
+	rootCmd.PersistentFlags().StringP("env-file", "e", ".env", "Environment file")
+	if err := rootCmd.MarkPersistentFlagFilename("env-file", "env"); err != nil {
+		log.Fatal(err)
+	}
+	if err := viper.BindPFlag("DotenvFile", rootCmd.PersistentFlags().Lookup("env-file")); err != nil {
+		log.Fatal(err)
+	}
+
 }
 
 // Execute method executes the 'Run' method of rootCmd.

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -8,7 +8,7 @@ func init() {
 	// Settings file
 	viper.SetConfigName("settings")
 	viper.SetConfigType("yaml")
-	viper.AddConfigPath("../../")
+	viper.AddConfigPath(".")
 	viper.AddConfigPath("$HOME/.dunner/")
 	viper.AddConfigPath("/etc/dunner/")
 	// TODO Add standard configuration paths for Windows OS
@@ -19,6 +19,7 @@ func init() {
 
 	// Files
 	viper.SetDefault("DunnerTaskFile", ".dunner.yaml")
+	viper.SetDefault("DotenvFile", ".env")
 	viper.SetDefault("GlobalLogFile", "/var/log/dunner/logs/")
 	viper.SetDefault("LocalLogFile", nil)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,9 +1,15 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/leopardslab/Dunner/internal/logger"
+	"github.com/spf13/viper"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -34,5 +40,67 @@ func GetConfigs(filename string) (*Configs, error) {
 		log.Fatal(err)
 	}
 
+	if err := parseEnv(&configs); err != nil {
+		log.Fatal(err)
+	}
+
 	return &configs, nil
+}
+
+func parseEnv(configs *Configs) error {
+	file := viper.GetString("DotenvFile")
+	envs, err := godotenv.Read(file)
+	if err != nil {
+		log.Warn(err)
+	}
+
+	for k, tasks := range (*configs).Tasks {
+		for j, task := range tasks {
+			for i, envVar := range task.Envs {
+				var str = strings.Split(envVar, "=")
+				if len(str) != 2 {
+					return fmt.Errorf(
+						`config: invalid format of environment variable: %v`,
+						envVar,
+					)
+				}
+				var pattern = "^`\\$.+`$"
+				check, err := regexp.MatchString(pattern, str[1])
+				if err != nil {
+					log.Fatal(err)
+				}
+				if check {
+					var key = strings.Replace(
+						strings.Replace(
+							str[1],
+							"`",
+							"",
+							-1,
+						),
+						"$",
+						"",
+						1,
+					)
+					var val string
+					if v, isSet := os.LookupEnv(key); isSet {
+						val = v
+					}
+					if v, isSet := envs[key]; isSet {
+						val = v
+					}
+					if val == "" {
+						return fmt.Errorf(
+							`config: could not find environment variable '%v' in %s file or among host environment variables`,
+							key,
+							file,
+						)
+					}
+					var newEnv = str[0] + "=" + val
+					(*configs).Tasks[k][j].Envs[i] = newEnv
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ type Task struct {
 	Name    string   `yaml:"name"`
 	Image   string   `yaml:"image"`
 	Command []string `yaml:"command"`
+	Envs    []string `yaml:"envs"`
 }
 
 // Configs describes the parsed information from the dunner file
@@ -34,21 +35,4 @@ func GetConfigs(filename string) (*Configs, error) {
 	}
 
 	return &configs, nil
-}
-
-// GetAllImages extracts a set of images required for all the tasks to run
-func (c *Configs) GetAllImages() ([]string, error) {
-	var images []string
-	var set = make(map[string]bool)
-
-	for _, tasks := range c.Tasks {
-		for _, task := range tasks {
-			set[task.Image] = true
-		}
-	}
-
-	for img := range set {
-		images = append(images, img)
-	}
-	return images, nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,11 +45,6 @@ func TestGetConfigs(t *testing.T) {
 		Tasks: tasks,
 	}
 
-	imgs, _ := expected.GetAllImages()
-	if !reflect.DeepEqual([]string{task.Image}, imgs) {
-		t.Fatalf("Images list not equal to expected")
-	}
-
 	if !reflect.DeepEqual(expected, *pout) {
 		t.Fatalf("Output not equal to expected")
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,9 +10,12 @@ import (
 func TestGetConfigs(t *testing.T) {
 	var tmpFilename = ".testdunner.yaml"
 
-	var content = []byte(`test:
-    - image: node
-      command: ["node", "--version"]`)
+	var content = []byte(`
+test:
+  - image: node
+    command: ["node", "--version"]
+    envs:
+      - MYVAR=MYVAL`)
 
 	tmpFile, err := ioutil.TempFile("", tmpFilename)
 	if err != nil {
@@ -38,6 +41,7 @@ func TestGetConfigs(t *testing.T) {
 		Name:    "",
 		Image:   "node",
 		Command: []string{"node", "--version"},
+		Envs:    []string{"MYVAR=MYVAL"},
 	}
 	var tasks = make(map[string][]Task)
 	tasks["test"] = []Task{task}
@@ -46,7 +50,7 @@ func TestGetConfigs(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, *pout) {
-		t.Fatalf("Output not equal to expected")
+		t.Fatalf("Output not equal to expected; %v != %v", expected, *pout)
 	}
 
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -25,7 +25,7 @@ type Step struct {
 	Name    string
 	Image   string
 	Command []string
-	Env     map[string]string
+	Env     []string
 	WorkDir string
 	Volumes map[string]string
 }
@@ -80,6 +80,7 @@ func (step Step) Exec() (*io.ReadCloser, error) {
 		&container.Config{
 			Image:      step.Image,
 			Cmd:        step.Command,
+			Env:        step.Env,
 			WorkingDir: containerWorkingDir,
 		},
 		&container.HostConfig{

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -41,6 +41,7 @@ func Do(_ *cobra.Command, args []string) {
 			Name:    stepDefinition.Name,
 			Image:   stepDefinition.Image,
 			Command: stepDefinition.Command,
+			Env:     stepDefinition.Envs,
 		}
 		if async {
 			go process(&step, &wg)


### PR DESCRIPTION
Resolves #2 and #42.
* Pass environment variables to tasks to be run in containers.
* Use [godotenv](https://github.com/joho/godotenv) to parse `.env` files.
* Bind a flag to choose `.env` file.
* Also check if the variable is present in host environment variables.