### PR TITLE
Add ability to mount external directories

### DIFF
--- a/.dunner.yaml
+++ b/.dunner.yaml
@@ -1,8 +1,4 @@
 build:
-  - image: node
-    command: ["node", "--version"]
-  - image: node
-    command: ["npm", "--version"]
   - image: node:10.15.0
     command: ["node", "--version"]
   - image: node:10.15.0
@@ -15,3 +11,9 @@ build:
       - PERM=775
       - ID=dunner
       - DIR=`$HOME`
+  - image: alpine
+    command: ["ls", "/root"]
+    mounts:
+      - '~/Downloads:/root/down'
+      - ~/Pictures:/root/pics:wr
+      - "~/Documents:/root/docs:r"

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -21,13 +21,14 @@ var log = logger.Log
 
 // Step describes the information required to run one task in docker container
 type Step struct {
-	Task    string
-	Name    string
-	Image   string
-	Command []string
-	Env     []string
-	WorkDir string
-	Volumes map[string]string
+	Task      string
+	Name      string
+	Image     string
+	Command   []string
+	Env       []string
+	WorkDir   string
+	Volumes   map[string]string
+	ExtMounts []mount.Mount
 }
 
 // Exec method is used to execute the task described in the corresponding step
@@ -84,13 +85,11 @@ func (step Step) Exec() (*io.ReadCloser, error) {
 			WorkingDir: containerWorkingDir,
 		},
 		&container.HostConfig{
-			Mounts: []mount.Mount{
-				{
-					Type:   mount.TypeBind,
-					Source: path,
-					Target: hostMountTarget,
-				},
-			},
+			Mounts: append(step.ExtMounts, mount.Mount{
+				Type:   mount.TypeBind,
+				Source: path,
+				Target: hostMountTarget,
+			}),
 		},
 		nil, "")
 	if err != nil {

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -43,6 +43,11 @@ func Do(_ *cobra.Command, args []string) {
 			Command: stepDefinition.Command,
 			Env:     stepDefinition.Envs,
 		}
+
+		if err := config.DecodeMount(stepDefinition.Mounts, &step); err != nil {
+			log.Fatal(err)
+		}
+
 		if async {
 			go process(&step, &wg)
 		} else {


### PR DESCRIPTION
Supported syntaxes for mounts:
* `<src>:<dest>:<mode>`
* `"<src>:<dest>:<mode>"`
* `'<src>:<dest>:<mode>'`

There are two modes:
* read-only: `r`
* read-write: `wr`/`w`

Defining mode is optional; by default, the read-only mode is chosen.