### PR TITLE
Updating the task reference syntax

### DIFF
--- a/.dunner.yaml
+++ b/.dunner.yaml
@@ -16,7 +16,7 @@ build:
       - PERM=775
       - ID=dunner
       - DIR=`$HOME`
-  - name: '@show'
+  - follow: 'show'
     args:
       - '/root'
 show:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ deploy:
    - AWS_ACCESS_KEY_ID=`$AWS_KEY`
    - AWS_SECRET_ACCESS_KEY=`$AWS_SECRET`
    - AWS_DEFAULT_REGION=us-east1
-- name: '@status' #This refers to another task and can pass args too
+- follow: 'status' #This refers to another task and can pass args too
   args: 'prod'
 status:
 - image: 'mesosphere/aws-cli'

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ type Task struct {
 	Commands [][]string `yaml:"commands"`
 	Envs     []string   `yaml:"envs"`
 	Mounts   []string   `yaml:"mounts"`
+	Follow   string     `yaml:"follow"`
 	Args     []string   `yaml:"args"`
 }
 

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -35,6 +35,7 @@ type Step struct {
 	WorkDir   string
 	Volumes   map[string]string
 	ExtMounts []mount.Mount
+	Follow    string
 	Args      []string
 }
 

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -50,6 +50,7 @@ func execTask(configs *config.Configs, taskName string, args []string) {
 			Commands: stepDefinition.Commands,
 			Env:      stepDefinition.Envs,
 			WorkDir:  stepDefinition.SubDir,
+			Follow:   stepDefinition.Follow,
 			Args:     stepDefinition.Args,
 		}
 
@@ -73,16 +74,15 @@ func process(configs *config.Configs, s *docker.Step, wg *sync.WaitGroup, args [
 		defer wg.Done()
 	}
 
-	if newTask := regexp.MustCompile(`^@\w+$`).FindString(s.Name); newTask != "" {
-		newTask = strings.Trim(newTask, "@")
+	if s.Follow != "" {
 		if async {
 			wg.Add(1)
 			go func(wg *sync.WaitGroup) {
-				execTask(configs, newTask, s.Args)
+				execTask(configs, s.Follow, s.Args)
 				wg.Done()
 			}(wg)
 		} else {
-			execTask(configs, newTask, s.Args)
+			execTask(configs, s.Follow, s.Args)
 		}
 		return
 	}


### PR DESCRIPTION
Resolves #58
To use a task as a step for another task, the way of referencing it should be more intuitive. 
Current syntax:
```yaml
deploy:
- image: 'node'
  command: ['node', '--version']
- name: '@status'
```
Proposed syntax:
```yaml
deploy:
- image: 'node'
  command: ['node', '--version']
- follow: 'status'
```