### PR TITLE
Implement dry-run mode

### DIFF
--- a/cmd/do.go
+++ b/cmd/do.go
@@ -10,8 +10,14 @@ func init() {
 	rootCmd.AddCommand(doCmd)
 
 	// Async Mode
-	doCmd.Flags().BoolP("async", "A", false, "Async mode")
+	doCmd.Flags().BoolP("async", "A", false, "Asynchronous mode")
 	if err := viper.BindPFlag("Async", doCmd.Flags().Lookup("async")); err != nil {
+		log.Fatal(err)
+	}
+
+	// Dry-run mode
+	doCmd.Flags().Bool("dry-run", false, "Dry-run of the command")
+	if err := viper.BindPFlag("Dry-run", doCmd.Flags().Lookup("dry-run")); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -29,6 +29,7 @@ func Init() {
 	// Modes
 	viper.SetDefault("Async", false)
 	viper.SetDefault("Verbose", false)
+	viper.SetDefault("Dry-run", false)
 
 	// Constants
 	viper.SetDefault("DockerAPIVersion", "1.39")

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -143,35 +143,38 @@ func (step Step) Exec() (*[]Result, error) {
 	}()
 
 	var results []Result
-	if multipleCommands {
-		for _, cmd := range step.Commands {
-			r, err := runCmd(ctx, cli, resp.ID, cmd)
+	if dryRun := viper.GetBool("Dry-run"); !dryRun {
+		if multipleCommands {
+			for _, cmd := range step.Commands {
+				r, err := runCmd(ctx, cli, resp.ID, cmd)
+				if err != nil {
+					log.Fatal(err)
+				}
+				results = append(results, *r)
+			}
+		} else {
+			statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+			select {
+			case err = <-errCh:
+				if err != nil {
+					log.Fatal(err)
+				}
+			case <-statusCh:
+			}
+
+			out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: true,
+			})
 			if err != nil {
 				log.Fatal(err)
 			}
-			results = append(results, *r)
-		}
-	} else {
-		statusCh, errCh := cli.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
-		select {
-		case err = <-errCh:
-			if err != nil {
-				log.Fatal(err)
-			}
-		case <-statusCh:
-		}
 
-		out, err := cli.ContainerLogs(ctx, resp.ID, types.ContainerLogsOptions{
-			ShowStdout: true,
-			ShowStderr: true,
-		})
-		if err != nil {
-			log.Fatal(err)
+			results = []Result{*extractResult(out, step.Command)}
 		}
-
-		results = []Result{*extractResult(out, step.Command)}
+		return &results, nil
 	}
-	return &results, nil
+	return nil, nil
 }
 
 func runCmd(ctx context.Context, cli *client.Client, containerID string, command []string) (*Result, error) {

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -100,6 +100,10 @@ func process(configs *config.Configs, s *docker.Step, wg *sync.WaitGroup, args [
 		log.Fatal(err)
 	}
 
+	if results == nil {
+		return
+	}
+
 	for _, res := range *results {
 		log.Infof(
 			"Running task '%+v' on '%+v' Docker with command '%+v'",


### PR DESCRIPTION
Resolves #56.
In the `dry-run` mode, Dunner will do all the other processes like parsing the config file, pulling images, creating containers, mounting directories, but not the execution of commands.