### PR TITLE
Integrate with codecov to get code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,8 @@ before_install:
 install:
   - dep ensure -v
 
-script: go test -v ./...
+script:
+  - go test ./...  -race -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - chmod +x $GOPATH/bin/dep
 
 install:
-  - $GOPATH/bin/dep ensure -v
+  - make setup
   - sudo snap install snapcraft --classic
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ install:
 build: install
 	@$(GOINSTALL) -ldflags "-X main.version=$(VERSION)-$(SHA) -s"
 
-ci: test
+ci: build fmt lint vet
+	@go test -v $(ALL_PACKAGES) -race -coverprofile=coverage.txt -covermode=atomic
 
 test: build
 	@go test -v $(ALL_PACKAGES)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ setup: install
 	@go get -u golang.org/x/lint/golint
 
 install: 
-	@$(DEP) ensure
+	@$(DEP) ensure -v
 
 build: install
 	@$(GOINSTALL) -ldflags "-X main.version=$(VERSION)-$(SHA) -s"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dunner
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b2275e331d2745dc9527d45efbbf2da2)](https://app.codacy.com/app/Leopardslab/dunner?utm_source=github.com&utm_medium=referral&utm_content=leopardslab/dunner&utm_campaign=Badge_Grade_Dashboard)
+[![Codecov branch](https://img.shields.io/codecov/c/github/leopardslab/dunner/master.svg?style=for-the-badge)](https://codecov.io/gh/leopardslab/dunner)
 
 Dunner is a task runner tool like Grunt but uses Docker images like CircleCI do. You can define tasks and steps of the tasks in your `.dunner.yaml` file and then run these steps with `Dunner do taskname`
 


### PR DESCRIPTION
ToDo: 
* Register Dunner repository in [Codecov](https://codecov.io/)
* Add the `CODECOV_TOKEN` in travis CI for repo identification
(This can be done by owner access only I think)

This PR adds the scripts to publish code coverage reports from travis CI and add the badge on README.