### PR TITLE
Automate Dunner Release as binary, tar, deb, rpm, snap for all os/arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 # Environment file
 .env
+
+# Packages
+dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,63 @@
+# Goreleaser documentation at http://goreleaser.com
+project_name: dunner
+builds:
+- env:
+    - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+    - arm
+    - arm64
+archives:
+- replacements:
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - Merge pull request
+    - Merge branch
+    - Update readme
+snapshot:
+  name_template: "{{.ProjectName}}_{{.Tag}}"
+
+brew:
+  github:
+    owner: leopardslab
+    name: homebrew-dunner
+  folder: Formula
+  homepage:  https://github.com/leopardslab/Dunner
+  description: A Docker based task runner tool
+  test: |
+    system "#{bin}/dunner version"
+
+nfpm:
+  name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  homepage:  https://github.com/leopardslab/Dunner
+  description: A Docker based task runner tool
+  license: MIT
+  formats:
+  - deb
+  - rpm
+  dependencies:
+  - git
+  recommends:
+  - rpm
+snapcraft:
+  name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  summary: A Docker based task runner tool
+  description: |
+    Dunner is a task runner tool like Grunt but used Docker images like CircleCI do. | 
+    You can define tasks and steps of the tasks in your `.dunner.yaml` file and then run these steps with `Dunner do taskname`
+  grade: stable
+  confinement: devmode
+  publish: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ env:
   - PATH=/snap/bin:$PATH
 
 before_install:
-  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - curl -L -s -v https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
+  - ls -al $GOPATH/bin
   - dep version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ go:
   - master
 
 env:
-  - DEP_VERSION="0.5.0"
-  - PATH=/snap/bin:$PATH
+  global:
+    - DEP_VERSION="0.5.0"
+    - PATH=/snap/bin:$PATH
 
 services:
   - docker
@@ -17,9 +18,8 @@ addons:
     - snapd
 
 before_install:
-  - curl -L -s -v https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
-  - $GOPATH/bin/dep version
 
 install:
   - $GOPATH/bin/dep ensure -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 before_install:
   - curl -L -s -v https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
-  - dep version
+  - $GOPATH/bin/dep version
 
 install:
   - $GOPATH/bin/dep ensure -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ env:
 
 services:
   - docker
+addons:
+  apt:
+    packages:
+    - rpm
+    - snapd
+env:
+  - PATH=/snap/bin:$PATH
 
 before_install:
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
@@ -16,5 +23,20 @@ before_install:
 
 install:
   - dep ensure -v
+  - sudo snap install snapcraft --classic
 
-script: go test -v ./...
+script:
+  - make ci
+
+after_success:
+  - test -n "$TRAVIS_TAG" && snapcraft login --with snap.login
+
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  verbose: true
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux
+    master: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 
 env:
   - DEP_VERSION="0.5.0"
+  - PATH=/snap/bin:$PATH
 
 services:
   - docker
@@ -14,17 +15,14 @@ addons:
     packages:
     - rpm
     - snapd
-env:
-  - PATH=/snap/bin:$PATH
 
 before_install:
   - curl -L -s -v https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
-  - ls -al $GOPATH/bin
   - dep version
 
 install:
-  - dep ensure -v
+  - $GOPATH/bin/dep ensure -v
   - sudo snap install snapcraft --classic
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 before_install:
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
   - chmod +x $GOPATH/bin/dep
+  - dep version
 
 install:
   - dep ensure -v

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,8 @@ test-coverage:
 	tail -n +2 coverage.out >> coverage-all.out;)
 	@go tool cover -html=coverage-all.out -o coverage.html
 
+release:
+	@echo "Make sure you run this on master branch to make a release"
+	@echo "Adding tag for version: $(VERSION)"
+	git tag -a $(VERSION) -m "Release version $(VERSION)"
+	@echo "Run \"git push origin $(VERSION)\" to push tag to remote which makes a dunner release!"

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,5 @@ build:	install
 
 clean:
 	rm -rf *
+
+ci: build test

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build: install
 ci: test
 
 test: build
-	@go -v $(ALL_PACKAGES)
+	@go test -v $(ALL_PACKAGES)
 
 vet:
 	@go vet $(ALL_PACKAGES)


### PR DESCRIPTION
Have tested this locally and works fine, generates all packages and installers.

ToDo:
* Verify `GITHUB_TOKEN` key is added to the environment. This token is used to create releases in github repository via Travis CI. 
* Setup snap login on CI:  `snapcraft export-login snap.login` and `travis encrypt-file snap.login --add` to add the key to the travis environment. More info [here](https://goreleaser.com/ci/).

* Try out in next release