### PR TITLE
Add dunner init command which initializes with default dunner task file

### DIFF
--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/leopardslab/dunner/pkg/initialize"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+var initCmd = &cobra.Command{
+	Use:     "init",
+	Short:   "Generates a dunner task file `.dunner.yaml`",
+	Long:    "You can initialize any project with dunner task file. It generates a default task file `.dunner.yaml`, you can customize it based on needs. You can override the name of task file using -t flag.",
+	Run:     initialize.Initialize,
+	Args:    cobra.NoArgs,
+	Aliases: []string{"i"},
+}

--- a/cmd/initialize.go
+++ b/cmd/initialize.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"github.com/leopardslab/dunner/internal/logger"
 	"github.com/leopardslab/dunner/pkg/initialize"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -13,7 +15,16 @@ var initCmd = &cobra.Command{
 	Use:     "init",
 	Short:   "Generates a dunner task file `.dunner.yaml`",
 	Long:    "You can initialize any project with dunner task file. It generates a default task file `.dunner.yaml`, you can customize it based on needs. You can override the name of task file using -t flag.",
-	Run:     initialize.Initialize,
+	Run:     Initialize,
 	Args:    cobra.NoArgs,
 	Aliases: []string{"i"},
+}
+
+// Initialize command invoked from command line generates a dunner task file with default template
+func Initialize(_ *cobra.Command, args []string) {
+	var dunnerFile = viper.GetString("DunnerTaskFile")
+	if err := initialize.InitProject(dunnerFile); err != nil {
+		logger.Log.Fatalf("Failed to initialize project: %s", err.Error())
+	}
+	logger.Log.Infof("Dunner task file `%s` created. Please make any required changes.", dunnerFile)
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -14,11 +14,12 @@ func init() {
 }
 
 var validateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validate the dunner task file `.dunner.yaml`",
-	Long:  "You can validate task file `.dunner.yaml` with this command to see if there are any parse errors",
-	Run:   Validate,
-	Args:  cobra.MinimumNArgs(0),
+	Use:     "validate",
+	Short:   "Validate the dunner task file `.dunner.yaml`",
+	Long:    "You can validate task file `.dunner.yaml` with this command to see if there are any parse errors",
+	Run:     Validate,
+	Args:    cobra.NoArgs,
+	Aliases: []string{"v"},
 }
 
 // Validate command invoked from command line, validates the dunner task file. If there are errors, it fails with non-zero exit code.

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -10,10 +10,10 @@ build:
     commands:
       - ["npm", "--version"]
       - ["npm", "install"]
-    # List of directories that are to be mounted on the container
+    # (Optional) List of directories that are to be mounted on the container
     mounts:
       - /tmp:/tmp:w
-    # Set any environment variables to be exported in the container
+    # (Optional) Set any environment variables to be exported in the container
     envs:
       - PERM=775
 `

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -1,0 +1,22 @@
+package internal
+
+// DefaultTaskFileContents is the default dunner taskfile contents, used when initialized with dunner
+const DefaultTaskFileContents = `# This is an example dunner task file. Please make any required changes.
+build:
+  - name: setup
+    # Image name that has to be pulled from a registry
+    image: node:latest
+    # List of commands that has to be run inside the container
+    commands:
+      - ["npm", "--version"]
+      - ["npm", "install"]
+    # List of directories that are to be mounted on the container
+    mounts:
+      - /tmp:/tmp:w
+    # Set any environment variables to be exported in the container
+    envs:
+      - PERM=775
+`
+
+// DefaultTaskFilePermission is the default file permission of dunner task file
+const DefaultTaskFilePermission = 0644

--- a/pkg/initialize/initialize.go
+++ b/pkg/initialize/initialize.go
@@ -1,0 +1,32 @@
+package initialize
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/leopardslab/dunner/internal"
+	"github.com/leopardslab/dunner/internal/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Initialize command invoked from command line generates a dunner task file with default template
+func Initialize(_ *cobra.Command, args []string) {
+	var dunnerFile = viper.GetString("DunnerTaskFile")
+	if err := initProject(dunnerFile); err != nil {
+		logger.Log.Fatalf("Failed to initialize project: %s", err.Error())
+	}
+	logger.Log.Infof("Dunner task file `%s` created. Please make any required changes.", dunnerFile)
+}
+
+func initProject(filename string) error {
+	if _, err := os.Stat(filename); !os.IsNotExist(err) {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("%s already exists", filename)
+	}
+	logger.Log.Infof("Generating %s file", filename)
+	return ioutil.WriteFile(filename, []byte(internal.DefaultTaskFileContents), internal.DefaultTaskFilePermission)
+}

--- a/pkg/initialize/initialize.go
+++ b/pkg/initialize/initialize.go
@@ -7,20 +7,10 @@ import (
 
 	"github.com/leopardslab/dunner/internal"
 	"github.com/leopardslab/dunner/internal/logger"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-// Initialize command invoked from command line generates a dunner task file with default template
-func Initialize(_ *cobra.Command, args []string) {
-	var dunnerFile = viper.GetString("DunnerTaskFile")
-	if err := initProject(dunnerFile); err != nil {
-		logger.Log.Fatalf("Failed to initialize project: %s", err.Error())
-	}
-	logger.Log.Infof("Dunner task file `%s` created. Please make any required changes.", dunnerFile)
-}
-
-func initProject(filename string) error {
+// InitProject generates a dunner task file with default template
+func InitProject(filename string) error {
 	if _, err := os.Stat(filename); !os.IsNotExist(err) {
 		if err != nil {
 			return err

--- a/pkg/initialize/initialize_test.go
+++ b/pkg/initialize/initialize_test.go
@@ -32,11 +32,11 @@ func setup(t *testing.T) func() {
 	}
 }
 
-func TestInitializeSuccess(t *testing.T) {
+func TestInitProjectSuccess(t *testing.T) {
 	revert := setup(t)
 	defer revert()
 	var filename = ".test_dunner.yml"
-	if err := initProject(filename); err != nil {
+	if err := InitProject(filename); err != nil {
 		t.Errorf("Failed to open dunner task file %s: %s", filename, err.Error())
 	}
 
@@ -63,7 +63,22 @@ func TestInitializeWhenFileExists(t *testing.T) {
 	createFile(t, filename, internal.DefaultTaskFileContents)
 
 	expected := fmt.Sprintf("%s already exists", filename)
-	err := initProject(filename)
+	err := InitProject(filename)
+	if err == nil {
+		t.Errorf("expected: %s, got nil", expected)
+	}
+	if expected != err.Error() {
+		t.Errorf("expected: %s, got: %s", expected, err.Error())
+	}
+}
+
+func TestInitializeFilenameIsInvalid(t *testing.T) {
+	revert := setup(t)
+	defer revert()
+	var filename = "#Q$EJL_doesntexist/.test_dunner.yml"
+
+	expected := fmt.Sprintf("open %s: no such file or directory", filename)
+	err := InitProject(filename)
 	if err == nil {
 		t.Errorf("expected: %s, got nil", expected)
 	}

--- a/pkg/initialize/initialize_test.go
+++ b/pkg/initialize/initialize_test.go
@@ -1,0 +1,79 @@
+package initialize
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/leopardslab/dunner/internal"
+	"github.com/leopardslab/dunner/pkg/config"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func setup(t *testing.T) func() {
+	folder, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("Failed to create temp dir: %s", err.Error())
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Failed to get working directory: %s", err.Error())
+	}
+
+	if err = os.Chdir(folder); err != nil {
+		t.Errorf("Failed to change working directory: %s", err.Error())
+	}
+	return func() {
+		if err = os.Chdir(previous); err != nil {
+			t.Errorf("Failed to revert change in working directory: %s", err.Error())
+		}
+	}
+}
+
+func TestInitializeSuccess(t *testing.T) {
+	revert := setup(t)
+	defer revert()
+	var filename = ".test_dunner.yml"
+	if err := initProject(filename); err != nil {
+		t.Errorf("Failed to open dunner task file %s: %s", filename, err.Error())
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		t.Errorf("Failed to open dunner task file %s: %s", filename, err.Error())
+	}
+
+	fileContents, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Errorf("Failed to read dunner task file %s: %s", filename, err.Error())
+	}
+
+	var configs config.Configs
+	if err := yaml.Unmarshal(fileContents, &configs.Tasks); err != nil {
+		t.Errorf("Task file config structure invalid: %s", err.Error())
+	}
+}
+
+func TestInitializeWhenFileExists(t *testing.T) {
+	revert := setup(t)
+	defer revert()
+	var filename = ".test_dunner.yml"
+	createFile(t, filename, internal.DefaultTaskFileContents)
+
+	expected := fmt.Sprintf("%s already exists", filename)
+	err := initProject(filename)
+	if err == nil {
+		t.Errorf("expected: %s, got nil", expected)
+	}
+	if expected != err.Error() {
+		t.Errorf("expected: %s, got: %s", expected, err.Error())
+	}
+}
+
+func createFile(t *testing.T, filename, contents string) {
+	if err := ioutil.WriteFile(filename, []byte(contents), 0644); err != nil {
+		t.Errorf("Failed to create file: %s", err.Error())
+	}
+}


### PR DESCRIPTION
`dunner init` or `dunner i` initializes project with default dunner task file.

Fixes #78 