### PR TITLE
Limit release on Golang 1.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ deploy:
   on:
     tags: true
     condition: "$TRAVIS_OS_NAME = linux"
-    master: true
+    branch: master
+    go: 1.11.x


### PR DESCRIPTION
Limit the Travis deployment to commits with tags on `master` branch with OS as Linux and Golang version 1.11.x

Reference: https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on