### PR TITLE
Build all binaries and packages in release branch, skip publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,16 @@ deploy:
 
 - provider: script
   skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash -s -- --rm-dist --skip-publish
+  verbose: true
+  on:
+    condition: "$TRAVIS_OS_NAME = linux"
+    branch:
+      - /^release\/.*$/
+    go: 1.11.x
+
+- provider: script
+  skip_cleanup: true
   script: bash release/publish_rpm_to_bintray.sh
   verbose: true
   on:


### PR DESCRIPTION
On branch with names as `release/v2.1.4` dunner binaries/packages are built to ensure its working fine. But its not published to any repository. This is done so that master branch does not fail if there is an error in building binaries during release. 

Steps to create a new release: 

* Make `release/<version>` branch from develop. (Release candidate)
* Make sure build passes 
* Merge it to `master` and back to `develop`
* Push a git tag to `release/<v>` branch as: 
    * Run `make release VERSION=v2.1.4` on cli
    * Run `git push origin <version>` to push tag to remote which makes dunner release!

@agentmilindu Please review the steps. 
