### PR TITLE
Fix publish deb and rpm packages to Bintray

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Goreleaser documentation at http://goreleaser.com
 project_name: dunner
+
 builds:
 - env:
     - CGO_ENABLED=0
@@ -14,7 +15,8 @@ builds:
     - arm64
 
 archives:
-- replacements:
+-
+  replacements:
     386: i386
     amd64: x86_64
 checksum:
@@ -45,12 +47,16 @@ brews:
   test: |
     system "#{bin}/dunner version"
 
-nfpm:
-  name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+nfpms:
+-
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   homepage:  https://github.com/leopardslab/Dunner
   description: A Docker based task runner tool
   maintainer: LeopardsLab Community
   license: MIT
+  replacements:
+    386: i386
+    amd64: x86_64
   formats:
   - deb
   - rpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,13 @@ deploy:
     condition: "$TRAVIS_OS_NAME = linux"
     branch: master
     go: 1.11.x
+
+- provider: script
+  skip_cleanup: true
+  script: bash release/publish_rpm_to_bintray.sh
+  verbose: true
+  on:
+    tags: true
+    condition: "$TRAVIS_OS_NAME = linux"
+    branch: master
+    go: 1.11.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,6 @@ deploy:
 
 - provider: script
   skip_cleanup: true
-  script: bash release/publish_rpm_to_bintray.sh
-  verbose: true
-  on:
-    tags: true
-    condition: "$TRAVIS_OS_NAME = linux"
-    branch: master
-    go: 1.11.x
-
-- provider: script
-  skip_cleanup: true
   script: bash release/publish_deb_to_bintray.sh
   verbose: true
   on:

--- a/release/publish_deb_to_bintray.sh
+++ b/release/publish_deb_to_bintray.sh
@@ -8,13 +8,13 @@ DISTRIBUTIONS="stable"
 COMPONENTS="main"
 GORELEASER_DIR="dist"
 
-if [ -z "$USER" ]; then
-  echo "USER is not set"
+if [ -z "$BINTRAY_USER" ]; then
+  echo "BINTRAY_USER is not set"
   exit 1
 fi
 
-if [ -z "$API_KEY" ]; then
-  echo "API_KEY is not set"
+if [ -z "$BINTRAY_API_KEY" ]; then
+  echo "BINTRAY_API_KEY is not set"
   exit 1
 fi
 
@@ -47,7 +47,7 @@ bintrayUpload () {
     URL="https://api.bintray.com/content/leopardslab/$REPO/$PACKAGE/$VERSION/$UPLOADDIRPATH/$FILENAME;deb_distribution=$DISTRIBUTIONS;deb_component=$COMPONENTS;deb_architecture=$ARCH?publish=1&override=1"
     echo "Uploading $URL"
 
-    RESPONSE=$(curl -T ./$GORELEASER_DIR/$FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
+    RESPONSE=$(curl -T ./$GORELEASER_DIR/$FILENAME -u$BINTRAY_USER:$BINTRAY_API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 
@@ -72,7 +72,7 @@ bintraySetDownloads () {
     URL="https://api.bintray.com/file_metadata/leopardslab/$REPO/$UPLOADDIRPATH/$FILENAME"
 
     echo "Putting $FILENAME in $PACKAGE's download list"
-    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
+    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$BINTRAY_USER:$BINTRAY_API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 

--- a/release/publish_deb_to_bintray.sh
+++ b/release/publish_deb_to_bintray.sh
@@ -6,6 +6,7 @@ REPO="dunner-deb"
 PACKAGE="dunner"
 DISTRIBUTIONS="stable"
 COMPONENTS="main"
+GORELEASER_DIR="dist"
 
 if [ -z "$USER" ]; then
   echo "USER is not set"
@@ -18,47 +19,39 @@ if [ -z "$API_KEY" ]; then
 fi
 
 setVersion () {
+  echo "Fetching latest dunner version from Github releases.."
   VERSION=$(curl --silent "https://api.github.com/repos/leopardslab/dunner/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/');
+  echo "Latest dunner version: $VERSION"
+  if [ "$VERSION" == "" ]; then
+    exit 1
+  fi
+  VERSIONNUMBER=$(echo $VERSION | cut -d 'v' -f 2)
+  FILES=( "dunner_$(echo $VERSIONNUMBER)_linux_arm.deb" "dunner_$(echo $VERSIONNUMBER)_linux_arm64.deb" "dunner_$(echo $VERSIONNUMBER)_linux_i386.deb" "dunner_$(echo $VERSIONNUMBER)_linux_x86_64.deb" )
 }
 
 setUploadDirPath () {
   UPLOADDIRPATH="pool/d/$PACKAGE"
 }
 
-downloadDebianArtifacts() {
-  echo "Dowloading debian artifacts"
-  FILES=$(curl -s https://api.github.com/repos/leopardslab/dunner/releases/latest \
-| grep "browser_download_url.*deb" \
-| cut -d : -f 3 \
-| sed -e 's/^/https:/' \
-| tr -d '"' );
-  echo $FILES
-  for i in $FILES; do
-    RESPONSE_CODE=$(curl -O  -w "%{response_code}" "$i")
-    code=$(echo "$RESPONSE_CODE" | head -c2)
-    if [ $code != "20" ] && [ $code != "30" ]; then
-      echo "Unable to download $i HTTP response code: $RESPONSE_CODE"
-    fi
-  done;
-  echo "Finished downloading"
-}
-
 bintrayUpload () {
-  for i in $FILES; do
-    FILENAME=${i##*/}
+  for i in "${FILES[@]}"; do
+    FILENAME=$i
     ARCH=$(echo ${FILENAME##*_} | cut -d '.' -f 1)
-    if [ $ARCH == "386" ]; then
+    if [ "$ARCH" == "386" ]; then
       ARCH="i386"
+    fi
+    if [ "$ARCH" == "64" ]; then
+      ARCH="x86_64"
     fi
 
     URL="https://api.bintray.com/content/leopardslab/$REPO/$PACKAGE/$VERSION/$UPLOADDIRPATH/$FILENAME;deb_distribution=$DISTRIBUTIONS;deb_component=$COMPONENTS;deb_architecture=$ARCH?publish=1&override=1"
     echo "Uploading $URL"
 
-    RESPONSE=$(curl -T $FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
+    RESPONSE=$(curl -T ./$GORELEASER_DIR/$FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 
-    if [ $HTTP_STATUS != "20" ] && [ $HTTP_STATUS != "30" ]; then
+    if [ "$(echo $HTTP_STATUS | head -c2)" != "20" ] && [ "$(echo $HTTP_STATUS | head -c2)" != "30" ]; then
       echo "Unable to upload, HTTP response code: $HTTP_STATUS"
       exit 1
     fi
@@ -67,11 +60,14 @@ bintrayUpload () {
 }
 
 bintraySetDownloads () {
-  for i in $FILES; do
-    FILENAME=${i##*/}
+  for i in "${FILES[@]}"; do
+    FILENAME=$i
     ARCH=$(echo ${FILENAME##*_} | cut -d '.' -f 1)
-    if [ $ARCH == "386" ]; then
+    if [ "$ARCH" == "386" ]; then
       ARCH="i386"
+    fi
+    if [ "$ARCH" == "64" ]; then
+      ARCH="x86_64"
     fi
     URL="https://api.bintray.com/file_metadata/leopardslab/$REPO/$UPLOADDIRPATH/$FILENAME"
 
@@ -80,7 +76,7 @@ bintraySetDownloads () {
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 
-    if [ $HTTP_STATUS != "20" ]; then
+    if [ "$(echo $HTTP_STATUS | head -c2)" != "20" ]; then
         echo "Unable to put in download list, HTTP response: $RESPONSE"
         exit 1
     fi
@@ -99,12 +95,6 @@ printMeta () {
     echo "Version to be uploaded: $VERSION"
 }
 
-cleanArtifacts () {
-  rm -f "$(pwd)/*.deb"
-}
-
-cleanArtifacts
-downloadDebianArtifacts
 setVersion
 printMeta
 setUploadDirPath

--- a/release/publish_deb_to_bintray.sh
+++ b/release/publish_deb_to_bintray.sh
@@ -54,13 +54,15 @@ bintrayUpload () {
     URL="https://api.bintray.com/content/leopardslab/$REPO/$PACKAGE/$VERSION/$UPLOADDIRPATH/$FILENAME;deb_distribution=$DISTRIBUTIONS;deb_component=$COMPONENTS;deb_architecture=$ARCH?publish=1&override=1"
     echo "Uploading $URL"
 
-    RESPONSE_CODE=$(curl -T $FILENAME -u$USER:$API_KEY $URL -I -s -w "%{response_code}" -o /dev/null);
-    code=$(echo "$RESPONSE_CODE" | head -c2)
-    if [ $code != "20" ] && [ $code != "30" ]; then
-      echo "Unable to upload, HTTP response code: $RESPONSE_CODE"
+    RESPONSE=$(curl -T $FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
+    HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    echo "$RESPONSE"
+
+    if [ $HTTP_STATUS != "20" ] && [ $HTTP_STATUS != "30" ]; then
+      echo "Unable to upload, HTTP response code: $HTTP_STATUS"
       exit 1
     fi
-    echo "HTTP response code: $RESPONSE_CODE"
+    echo "HTTP response code: $HTTP_STATUS"
   done;
 }
 
@@ -74,13 +76,15 @@ bintraySetDownloads () {
     URL="https://api.bintray.com/file_metadata/leopardslab/$REPO/$UPLOADDIRPATH/$FILENAME"
 
     echo "Putting $FILENAME in $PACKAGE's download list"
-    RESPONSE_CODE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY $URL -s -w "%{http_code}" -o /dev/null);
+    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
+    HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    echo "$RESPONSE"
 
-    if [ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]; then
-        echo "Unable to put in download list, HTTP response code: $RESPONSE_CODE"
+    if [ $HTTP_STATUS != "20" ]; then
+        echo "Unable to put in download list, HTTP response: $RESPONSE"
         exit 1
     fi
-    echo "HTTP response code: $RESPONSE_CODE"
+    echo "HTTP response code: $HTTP_STATUS"
   done
 }
 

--- a/release/publish_rpm_to_bintray.sh
+++ b/release/publish_rpm_to_bintray.sh
@@ -54,12 +54,15 @@ bintrayUpload () {
     URL="https://api.bintray.com/content/leopardslab/$REPO/$PACKAGE/$VERSION/$UPLOADDIRPATH/$FILENAME?publish=1&override=1"
     echo "Uploading $URL"
 
-    RESPONSE_CODE=$(curl -T $FILENAME -u$USER:$API_KEY $URL -I -s -w "%{http_code}" -o /dev/null);
-    if [[ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]]; then
-      echo "Unable to upload, HTTP response code: $RESPONSE_CODE"
+    RESPONSE=$(curl -T $FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
+    HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    echo "$RESPONSE"
+
+    if [[ $HTTP_STATUS != "20" ]]; then
+      echo "Unable to upload, HTTP response code: $HTTP_STATUS"
       exit 1
     fi
-    echo "HTTP response code: $RESPONSE_CODE"
+    echo "HTTP response code: $HTTP_STATUS"
   done;
 }
 
@@ -73,13 +76,15 @@ bintraySetDownloads () {
     URL="https://api.bintray.com/file_metadata/leopardslab/$REPO/$UPLOADDIRPATH/$FILENAME"
 
     echo "Putting $FILENAME in $PACKAGE's download list"
-    RESPONSE_CODE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY $URL -s -w "%{http_code}" -o /dev/null);
+    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
+    HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+    echo "$RESPONSE"
 
-    if [ "$(echo $RESPONSE_CODE | head -c2)" != "20" ]; then
-        echo "Unable to put in download list, HTTP response code: $RESPONSE_CODE"
+    if [ $HTTPSTATUS != "20" ]; then
+        echo "Unable to put in download list, HTTP response code: $HTTP_STATUS"
         exit 1
     fi
-    echo "HTTP response code: $RESPONSE_CODE"
+    echo "HTTP response code: $HTTP_STATUS"
   done
 }
 

--- a/release/publish_rpm_to_bintray.sh
+++ b/release/publish_rpm_to_bintray.sh
@@ -6,13 +6,13 @@ REPO="dunner-rpm"
 PACKAGE="dunner"
 GORELEASER_DIR="dist"
 
-if [ -z "$USER" ]; then
-  echo "USER is not set"
+if [ -z "$BINTRAY_USER" ]; then
+  echo "BINTRAY_USER is not set"
   exit 1
 fi
 
-if [ -z "$API_KEY" ]; then
-  echo "API_KEY is not set"
+if [ -z "$BINTRAY_API_KEY" ]; then
+  echo "BINTRAY_API_KEY is not set"
   exit 1
 fi
 
@@ -45,7 +45,7 @@ bintrayUpload () {
     URL="https://api.bintray.com/content/leopardslab/$REPO/$PACKAGE/$VERSION/$UPLOADDIRPATH/$FILENAME?publish=1&override=1"
     echo "Uploading $URL"
 
-    RESPONSE=$(curl -T ./$GORELEASER_DIR/$FILENAME -u$USER:$API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
+    RESPONSE=$(curl -T ./$GORELEASER_DIR/$FILENAME -u$BINTRAY_USER:$BINTRAY_API_KEY "$URL" -I -s -w "HTTPSTATUS:%{http_code}");
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 
@@ -70,7 +70,7 @@ bintraySetDownloads () {
     URL="https://api.bintray.com/file_metadata/leopardslab/$REPO/$UPLOADDIRPATH/$FILENAME"
 
     echo "Putting $FILENAME in $PACKAGE's download list"
-    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$USER:$API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
+    RESPONSE=$(curl -X PUT -d "{ \"list_in_downloads\": true }" -H "Content-Type: application/json" -u$BINTRAY_USER:$BINTRAY_API_KEY "$URL" -s -w "HTTPSTATUS:%{http_code}");
     HTTP_STATUS=$(echo $RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     echo "$RESPONSE"
 


### PR DESCRIPTION
* Use package file names with version so they are always unique. This should fix deb package publish.
* Upload directly using artifacts generated from goreleaser
* Rename environment keys of bintray user and api key to be specific

TODO: 
Rename USER=>BINTRAY_USER and API_KEY=> BINTRAY_API_KEY in travis environement with same values.