### PR TITLE
Fix No .env file WARN if misleading #110

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,7 +271,7 @@ func loadDotEnv() {
 	var err error
 	dotEnv, err = godotenv.Read(file)
 	if err != nil {
-		log.Warn(err)
+		log.Infof("No environment loaded from %s file: %s", file, err.Error())
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -271,7 +271,7 @@ func loadDotEnv() {
 	var err error
 	dotEnv, err = godotenv.Read(file)
 	if err != nil {
-		log.Infof("No environment loaded from %s file: %s", file, err.Error())
+		log.Infof("No environment loaded from %s file: Not found", file)
 	}
 }
 


### PR DESCRIPTION
Previously: 

```
WARN[2019-07-19 23:23:09] open .env: no such file or directory
```

Now:
 
```
INFO[2019-07-23 11:43:40] No environment loaded from .env file: open .env: no such file or directory
```

Fixes #110 