### PR TITLE
Add user field in dunner task | If not set, use current user

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -116,6 +116,9 @@ type Task struct {
 
 	// The list of arguments that are to be passed
 	Args []string `yaml:"args"`
+
+	// User that will run the command(s) inside the container, also support user:group
+	User string `yaml:"user"`
 }
 
 // Configs describes the parsed information from the dunner file. It is a map of task name as keys and the list of tasks

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,6 +17,7 @@ func TestGetConfigs(t *testing.T) {
 	var content = []byte(`
 test:
   - image: node
+    user: 20
     commands:
       - ["node", "--version"]
       - ["npm", "--version"]
@@ -47,6 +48,7 @@ test:
 		Name:     "",
 		Image:    "node",
 		Commands: [][]string{{"node", "--version"}, {"npm", "--version"}},
+		User:     "20",
 		Envs:     []string{"MYVAR=MYVAL"},
 	}
 	var tasks = make(map[string][]Task)

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -42,6 +42,7 @@ type Step struct {
 	ExtMounts []mount.Mount     // The directories to be mounted on the container as bind volumes
 	Follow    string            // The next task that must be executed if this does go successfully
 	Args      []string          // The list of arguments that are to be passed
+	User      string            // User that will run the command(s) inside the container, also support user:group
 }
 
 // Result stores the output of commands run using `docker exec`
@@ -116,6 +117,7 @@ func (step Step) Exec() (*[]Result, error) {
 			Cmd:        defaultCommand,
 			Env:        step.Env,
 			WorkingDir: containerWorkingDir,
+			User:       step.User,
 		},
 		&container.HostConfig{
 			Mounts: append(step.ExtMounts, mount.Mount{

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -165,7 +165,7 @@ func getDunnerUser(task config.Task) string {
 		user, err := os_user.Current()
 		if err != nil {
 			dunnerUser = os.Getenv("USER")
-			log.Debugf("Unable to find current user id: %s. Using `%s` as docker user.", err.Error(), dunnerUser)
+			log.Debugf("Unable to find current user id: %s. Using `%s` as Docker user.", err.Error(), dunnerUser)
 		} else {
 			dunnerUser = user.Uid
 		}

--- a/pkg/dunner/dunner_test.go
+++ b/pkg/dunner/dunner_test.go
@@ -1,0 +1,30 @@
+package dunner
+
+import (
+	os_user "os/user"
+	"testing"
+
+	"github.com/leopardslab/dunner/pkg/config"
+)
+
+func TestGetDunnerUserFromStep(t *testing.T) {
+	expected := "test_user"
+	task := config.Task{User: expected}
+
+	user := getDunnerUser(task)
+
+	if user != expected {
+		t.Errorf("got: %s, want: %s", user, expected)
+	}
+}
+
+func TestGetDunnerUserFromUserEnv(t *testing.T) {
+	user, _ := os_user.Current()
+	want := user.Uid
+
+	got := getDunnerUser(config.Task{})
+
+	if got != want {
+		t.Errorf("got: %s, want: %s", user, want)
+	}
+}


### PR DESCRIPTION
Fixes #111 

This PR adds a new field in dunner Task, `user` which if set will be passed as docker user as-is. If not set, it looks for `$UID`. If not available, uses current User's ID. If there is an error in getiing this, it uses `$USER`.