### PR TITLE
Image is required only if Follow is not present(alias task case)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -359,15 +359,15 @@
   version = "v1.20.1"
 
 [[projects]]
-  digest = "1:d9ed69c1d4d528e4a7779accc3ee070e68760cdd822f69ff2cf8ae0f677afbe2"
+  digest = "1:79f295f351615360f505af9029ee78ad995516cc3294cbfb7168a3cae3ecd079"
   name = "gopkg.in/go-playground/validator.v9"
   packages = [
     ".",
     "translations/en",
   ]
   pruneopts = "UT"
-  revision = "46b4b1e301c24cac870ffcb4ba5c8a703d1ef475"
-  version = "v9.28.0"
+  revision = "556b9da3c05f2a935bc086fb5a0bb55dd8112d2d"
+  version = "v9.29.1"
 
 [[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@
 
 [[constraint]]
   name = "gopkg.in/go-playground/validator.v9"
-  version = "9.28.0"
+  version = "9.29.1"
 
 [[constraint]]
   name = "github.com/go-playground/universal-translator"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/leopardslab/dunner/internal/util"
 	"github.com/leopardslab/dunner/pkg/docker"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 func TestGetConfigs(t *testing.T) {
@@ -100,13 +102,26 @@ func TestConfigs_ValidateWithEmptyImageAndCommand(t *testing.T) {
 		t.Fatalf("expected 2 errors, got %d : %s", len(errs), errs)
 	}
 
-	expected1 := "task 'stats': image is a required field"
+	expected1 := "task 'stats': image is required, unless the task has a `follow` field"
 	expected2 := "task 'stats': command[0] is a required field"
 	if errs[0].Error() != expected1 {
 		t.Fatalf("expected: %s, got: %s", expected1, errs[0].Error())
 	}
 	if errs[1].Error() != expected2 {
 		t.Fatalf("expected: %s, got: %s", expected2, errs[1].Error())
+	}
+}
+
+func TestConfigs_ValidateForAliasTask(t *testing.T) {
+	tasks := make(map[string][]Task, 0)
+	tasks["foo"] = []Task{Task{Image: "golang", Command: []string{"go", "version"}}}
+	tasks["stats"] = []Task{Task{Follow: "foo"}}
+	configs := &Configs{Tasks: tasks}
+
+	errs := configs.Validate()
+
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %d : %s", len(errs), errs)
 	}
 }
 
@@ -274,7 +289,18 @@ func TestInitValidatorForNilTranslation(t *testing.T) {
 
 	err := initValidator(vals)
 
-	expected := "failed to register validation: Function cannot be empty"
+	if err != nil {
+		t.Fatalf("expected nil, got %s", err)
+	}
+}
+
+func TestInitValidatorForEmptyTag(t *testing.T) {
+	vals := []customValidation{{tag: "", translation: "",
+		validationFn: func(context.Context, validator.FieldLevel) bool { return false }}}
+
+	err := initValidator(vals)
+
+	expected := "failed to register validation: Function Key cannot be empty"
 	if err == nil {
 		t.Fatalf("expected %s, got %s", expected, err)
 	}


### PR DESCRIPTION
```
setup:
  - image: golang
    command: ["ls"]
install:
  - follow: setup
```
Above dunner task will now not throw validation error with this PR. 

If both `image` and `follow` is not specified, error is displayed as:

```
task 'install': image is required, unless the task has a `follow` field
```

Fixes #107 