### PR TITLE
Add dunner tasks command | No tasks should not throw validation error

### DIFF
--- a/cmd/list_tasks.go
+++ b/cmd/list_tasks.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/leopardslab/dunner/internal/logger"
+	"github.com/leopardslab/dunner/pkg/dunner"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(listTasksCmd)
+}
+
+var listTasksCmd = &cobra.Command{
+	Use:     "tasks",
+	Short:   "Lists all available tasks in dunner task file",
+	Long:    "This lists all the available tasks in dunner task file, `.dunner.yaml` file by default or file passed to `-t` flag",
+	Run:     ListTasks,
+	Args:    cobra.NoArgs,
+}
+
+// ListTasks command invoked from command line lists all available dunner tasks
+func ListTasks(_ *cobra.Command, args []string) {
+	if err := dunner.ListTasks(); err != nil {
+		logger.Log.Fatalf("Failed to list dunner tasks: %s", err.Error())
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,7 +121,7 @@ type Task struct {
 // Configs describes the parsed information from the dunner file. It is a map of task name as keys and the list of tasks
 // associated with it.
 type Configs struct {
-	Tasks map[string][]Task `validate:"required,min=1,dive,keys,required,endkeys,required,min=1,required"`
+	Tasks map[string][]Task `validate:"dive,keys,required,endkeys,required,min=1,required"`
 }
 
 // Validate validates config and returns errors.
@@ -250,17 +250,17 @@ func ParseMountDir(ctx context.Context, fl validator.FieldLevel) bool {
 func GetConfigs(filename string) (*Configs, error) {
 	fileContents, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	var configs Configs
 	if err := yaml.Unmarshal(fileContents, &configs.Tasks); err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	loadDotEnv()
 	if err := ParseEnv(&configs); err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	return &configs, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -79,12 +79,8 @@ func TestConfigs_ValidateWithNoTasks(t *testing.T) {
 
 	errs := configs.Validate()
 
-	if len(errs) != 1 {
-		t.Fatalf("Configs validation failed, expected 1 error, got %s", errs)
-	}
-	expected := "Tasks must contain at least 1 item"
-	if errs[0].Error() != expected {
-		t.Fatalf("expected: %s, got: %s", expected, errs[0].Error())
+	if len(errs) != 0 {
+		t.Fatalf("Configs validation failed, expected no error, got %s", errs)
 	}
 }
 

--- a/pkg/dunner/list_tasks.go
+++ b/pkg/dunner/list_tasks.go
@@ -1,0 +1,38 @@
+package dunner
+
+import (
+	"fmt"
+
+	"github.com/leopardslab/dunner/pkg/config"
+	"github.com/spf13/viper"
+)
+
+// ListTasks lists all the available dunner tasks, if there are errors, it returns `error`
+func ListTasks() error {
+	var dunnerFile = viper.GetString("DunnerTaskFile")
+
+	configs, err := config.GetConfigs(dunnerFile)
+	if err != nil {
+		return err
+	}
+
+	errs := configs.Validate()
+	if len(errs) != 0 {
+		fmt.Println("Validation failed with following errors:")
+		for _, err := range errs {
+			fmt.Println(err.Error())
+		}
+		return fmt.Errorf("validation failed")
+	}
+
+	if len(configs.Tasks) == 0 {
+		fmt.Println("No dunner tasks found")
+	} else {
+		fmt.Println("Available Dunner tasks:")
+		for taskName := range configs.Tasks {
+			fmt.Println(taskName)
+		}
+		fmt.Println("Run `dunner do <task_name>` to run a dunner task.")
+	}
+	return nil
+}

--- a/pkg/dunner/list_tasks_test.go
+++ b/pkg/dunner/list_tasks_test.go
@@ -1,0 +1,106 @@
+package dunner
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func Test_ListTasksWhenConfigFileNotFound(t *testing.T) {
+	viper.Set("DunnerTaskFile", "fileThatDoesnotExit.yaml")
+
+	err := ListTasks()
+
+	expected := "open fileThatDoesnotExit.yaml: no such file or directory"
+	if err == nil {
+		t.Fatalf("got: %s, want: %s", err, expected)
+	}
+	if err.Error() != expected {
+		t.Fatalf("got: %s, want: %s", err.Error(), expected)
+	}
+}
+
+func Test_ListTasksWhenValidationFails(t *testing.T) {
+	var tmpFilename = ".testdunner.yaml"
+	var content = []byte(`
+setup:
+  - image: node
+    commands:
+      - ["node", "--version"]
+      - ["npm", "--version"]
+    envs:
+      - MYVAR=MYVAL
+build:
+  - command: []`)
+
+	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
+	defer os.Remove(tmpFile.Name())
+
+	err := ListTasks()
+
+	expected := "validation failed"
+	if err == nil {
+		t.Fatalf("got: %s, want: %s", err, expected)
+	}
+	if err.Error() != expected {
+		t.Fatalf("got: %s, want: %s", err.Error(), expected)
+	}
+}
+
+func Test_ListTasksSuccess(t *testing.T) {
+	var tmpFilename = ".testdunner.yaml"
+	var content = []byte(`
+setup:
+  - image: node
+    commands:
+      - ["node", "--version"]
+      - ["npm", "--version"]
+    envs:
+      - MYVAR=MYVAL
+build:
+  - image: node
+    command: []`)
+
+	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
+	defer os.Remove(tmpFile.Name())
+
+	err := ListTasks()
+
+	if err != nil {
+		t.Fatalf("got: %s, want: nil", err.Error())
+	}
+}
+
+func Test_ListTasksSuccessNoTasks(t *testing.T) {
+	var tmpFilename = ".testdunner.yaml"
+	var content = []byte("")
+
+	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
+	defer os.Remove(tmpFile.Name())
+
+	err := ListTasks()
+
+	if err != nil {
+		t.Fatalf("got: %s, want: nil", err.Error())
+	}
+}
+
+func createDunnerTaskFile(t *testing.T, content []byte, tmpFilename string) *os.File {
+	tmpFile, err := ioutil.TempFile("", tmpFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := tmpFile.Write(content); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	viper.Set("DunnerTaskFile", tmpFile.Name())
+	return tmpFile
+}


### PR DESCRIPTION
Running `dunner tasks` prints
```
Available Dunner tasks:
build
foo
Run `dunner do <task_name>` to run a dunner task.
```

If there are any validation errors, it prints them.

If there are no tasks in file, empty dunner task, then it will not throw error with this PR.
