### PR TITLE
Print command output after each command execution for better progress visibility

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -142,15 +142,12 @@ func (step Step) Exec() error {
 		}
 	}()
 
-	if dryRun := viper.GetBool("Dry-run"); dryRun {
-		return nil
-	}
-
 	commands := step.Commands
 	if len(commands) == 0 {
 		commands = append(commands, step.Command)
 	}
 
+	dryRun := viper.GetBool("Dry-run")
 	for _, cmd := range commands {
 		log.Infof(
 			"Running task '%+v' on '%+v' Docker with command '%+v'",
@@ -158,6 +155,10 @@ func (step Step) Exec() error {
 			step.Image,
 			strings.Join(cmd, " "),
 		)
+
+		if dryRun {
+			continue
+		}
 
 		r, err := runCmd(ctx, cli, resp.ID, cmd)
 		if err != nil {

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/leopardslab/dunner/internal/settings"
 )
 
-func ExampleStep_Do() {
+func ExampleStep_Exec() {
 	settings.Init()
 	var testNodeVersion = "10.15.0"
 	step := &Step{

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -1,13 +1,10 @@
 package docker
 
 import (
-	"strings"
-	"testing"
-
 	"github.com/leopardslab/dunner/internal/settings"
 )
 
-func TestStep_Do(t *testing.T) {
+func ExampleStep_Do() {
 	settings.Init()
 	var testNodeVersion = "10.15.0"
 	step := &Step{
@@ -19,14 +16,9 @@ func TestStep_Do(t *testing.T) {
 		Volumes:  nil,
 	}
 
-	results, err := step.Exec()
+	err := step.Exec()
 	if err != nil {
-		t.Error(err)
+		panic(err)
 	}
-
-	strOut := (*results)[0].Output
-	var result = strings.Trim(strings.Split(strOut, "v")[1], "\n")
-	if result != testNodeVersion {
-		t.Fatalf("Detected version of node container: '%s'; Expected output: '%s'", result, testNodeVersion)
-	}
+	// Output: OUT: v10.15.0
 }

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -109,28 +109,9 @@ func Process(configs *config.Configs, s *docker.Step, wg *sync.WaitGroup, args [
 		log.Fatalf(`dunner: image repository name cannot be empty`)
 	}
 
-	results, err := (*s).Exec()
+	err := (*s).Exec()
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	if results == nil {
-		return
-	}
-
-	for _, res := range *results {
-		log.Infof(
-			"Running task '%+v' on '%+v' Docker with command '%+v'",
-			s.Task,
-			s.Image,
-			res.Command,
-		)
-		if res.Output != "" {
-			fmt.Printf(`OUT: %s`, res.Output)
-		}
-		if res.Error != "" {
-			fmt.Printf(`ERR: %s`, res.Error)
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes #133 

With this change, 
* Output is printed per command, instead of waiting for all commands execution to complete. This gives better progress visibility to the user. 
* As per code, single command or multiple commands execution should not be different cases. 
