### PR TITLE
[#149] Show colored error output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,6 +84,14 @@
   version = "v0.4.0"
 
 [[projects]]
+  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
+  name = "github.com/fatih/color"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
+
+[[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
@@ -193,6 +201,22 @@
   version = "v1.8.1"
 
 [[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  digest = "1:9b90c7639a41697f3d4ad12d7d67dfacc9a7a4a6e0bbfae4fc72d0da57c28871"
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1311e847b0cb909da63b5fecfb5370aa66236465"
+  version = "v0.0.8"
+
+[[projects]]
   digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -295,12 +319,12 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:1b773526998f3dbde3a51a4a5881680c4d237d3600f570d900f97ac93c7ba0a8"
+  digest = "1:11118bd196646c6515fea3d6c43f66162833c6ae4939bfb229b9956d91c6cf17"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9"
-  version = "v1.3.2"
+  revision = "b5bf975e5823809fb22c7644d008757f78a4259e"
+  version = "v1.4.0"
 
 [[projects]]
   branch = "master"
@@ -388,6 +412,7 @@
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/stdcopy",
     "github.com/docker/docker/pkg/term",
+    "github.com/fatih/color",
     "github.com/go-playground/locales/en",
     "github.com/go-playground/universal-translator",
     "github.com/joho/godotenv",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "1.3.1"
+  version = "1.4.0"
 
 [[override]]
   name = "github.com/Nvveen/Gotty"
@@ -49,3 +49,7 @@
 [[constraint]]
   name = "github.com/go-playground/universal-translator"
   version = "0.16.0"
+
+[[constraint]]
+  name = "github.com/fatih/color"
+  version = "1.7.0"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ func init() {
 		log.Fatal(err)
 	}
 
+	// No color output
 	rootCmd.PersistentFlags().Bool("no-color", false, "No colored output")
 	if err := viper.BindPFlag("No-color", rootCmd.PersistentFlags().Lookup("no-color")); err != nil {
 		log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,6 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-
 	// Verbose Mode
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Verbose mode")
 	if err := viper.BindPFlag("Verbose", rootCmd.PersistentFlags().Lookup("verbose")); err != nil {
@@ -61,6 +60,11 @@ func init() {
 		log.Fatal(err)
 	}
 	if err := viper.BindPFlag("WorkingDirectory", rootCmd.PersistentFlags().Lookup("context")); err != nil {
+		log.Fatal(err)
+	}
+
+	rootCmd.PersistentFlags().Bool("no-color", false, "No colored output")
+	if err := viper.BindPFlag("No-color", rootCmd.PersistentFlags().Lookup("no-color")); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/leopardslab/dunner/internal/logger"
 	"github.com/leopardslab/dunner/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -24,6 +25,7 @@ var validateCmd = &cobra.Command{
 
 // Validate command invoked from command line, validates the dunner task file. If there are errors, it fails with non-zero exit code.
 func Validate(_ *cobra.Command, args []string) {
+	logger.InitColorOutput()
 	var dunnerFile = viper.GetString("DunnerTaskFile")
 
 	configs, err := config.GetConfigs(dunnerFile)
@@ -35,7 +37,7 @@ func Validate(_ *cobra.Command, args []string) {
 	if len(errs) != 0 {
 		fmt.Println("Validation failed with following errors:")
 		for _, err := range errs {
-			fmt.Println(err.Error())
+			logger.ErrorOutput(err.Error())
 		}
 		os.Exit(1)
 	}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -3,7 +3,9 @@ package logger
 import (
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 // Log is a globally configured logger
@@ -15,4 +17,16 @@ func init() {
 	Log.Formatter.(*logrus.TextFormatter).TimestampFormat = "2006-01-02 15:04:05" // Customize timestamp format
 	Log.Level = logrus.TraceLevel
 	Log.Out = os.Stdout
+}
+
+// InitColorOutput disables colorized output if no-color flag is passed
+func InitColorOutput() {
+	if viper.GetBool("No-color") {
+		color.NoColor = true
+	}
+}
+
+// ErrorOutput prints the given message in red color
+func ErrorOutput(format string, a ...interface{}) {
+	color.Red(format, a...)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,29 @@
+package logger
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestErrorOutput(t *testing.T) {
+	buf := new(bytes.Buffer)
+	oldOutput := color.Output
+	color.Output = buf
+	name := "dunner"
+	message := "Welcome!"
+
+	ErrorOutput("Hello %s! %s", name, message)
+
+	line, _ := buf.ReadString('\n')
+	got := fmt.Sprintf("%q", line)
+	expected := fmt.Sprintf("Hello %s! %s\n", name, message)
+	escaped := fmt.Sprintf("%q", expected)
+	color.Output = oldOutput
+
+	if got != escaped {
+		t.Fatalf("expected: %s, got: %s", escaped, got)
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/fatih/color"
+	"github.com/spf13/viper"
 )
 
 func TestErrorOutput(t *testing.T) {
@@ -25,5 +26,15 @@ func TestErrorOutput(t *testing.T) {
 
 	if got != escaped {
 		t.Fatalf("expected: %s, got: %s", escaped, got)
+	}
+}
+
+func TestInitColorOutput_True(t *testing.T) {
+	viper.Set("No-color", true)
+
+	InitColorOutput()
+
+	if color.NoColor != true {
+		t.Fatalf("expected no-color to be set as true, but got %v", color.NoColor)
 	}
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -35,6 +35,7 @@ func Init() {
 	viper.SetDefault("Async", false)
 	viper.SetDefault("Verbose", false)
 	viper.SetDefault("Dry-run", false)
+	viper.SetDefault("No-color", false)
 
 	// Constants
 	viper.SetDefault("DockerAPIVersion", "1.39")

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -18,6 +18,7 @@ func TestInit(t *testing.T) {
 		"verbose":          false,
 		"dry-run":          false,
 		"dockerapiversion": "1.39",
+		"no-color":         false,
 	}
 
 	if !reflect.DeepEqual(viper.AllSettings(), defaultSettings) {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -174,7 +174,7 @@ func (step Step) Exec() error {
 			fmt.Printf(`OUT: %s`, r.Output)
 		}
 		if r != nil && r.Error != "" {
-			fmt.Printf(`ERR: %s`, r.Error)
+			logger.ErrorOutput(`ERR: %s`, r.Error)
 		}
 	}
 	return nil

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -165,8 +165,8 @@ func (step Step) Exec() error {
 		if dryRun {
 			continue
 		}
-
 		r, err := runCmd(ctx, cli, resp.ID, cmd)
+
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -1,6 +1,8 @@
 package docker
 
 import (
+	"testing"
+
 	"github.com/leopardslab/dunner/internal/settings"
 	"github.com/spf13/viper"
 )
@@ -62,15 +64,13 @@ func runCommand(command []string, dir string, nodeVer string) error {
 	return step.Exec()
 }
 
-func ExampleStep_execWithErr() {
+func TestStep_execWithErr(t *testing.T) {
 	var testNodeVersion = "10.15.0"
 	var relPath = "./"
-	err := runCommand([]string{"ls", "/invalid_dir" +
-		""}, relPath, testNodeVersion)
+	err := runCommand([]string{"ls", "/invalid_dir"}, relPath, testNodeVersion)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	// Output: ERR: ls: cannot access '/invalid_dir': No such file or directory
 }
 
 func ExampleStep_execDryRun() {

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -23,6 +23,8 @@ var log = logger.Log
 
 // Do method is invoked for command-line use
 func Do(_ *cobra.Command, args []string) {
+	logger.InitColorOutput()
+
 	var async = viper.GetBool("Async")
 
 	if verbose := viper.GetBool("Verbose"); async && verbose {
@@ -40,7 +42,7 @@ func Do(_ *cobra.Command, args []string) {
 	if len(errs) != 0 {
 		fmt.Println("Validation failed with following errors:")
 		for _, err := range errs {
-			fmt.Println(err.Error())
+			logger.ErrorOutput(err.Error())
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
* Shows colored output, i.e error messages in red color on colorable terminals.
* Added a flag `--no-color` which can be passed if one wants simple output. By default, it shows colored output.
* Errors during `do` command and `validate` command are shown in red.

Fixes #149 