### PR TITLE
List tasks with bulleted points for ease to read

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -29,4 +30,9 @@ func InitColorOutput() {
 // ErrorOutput prints the given message in red color
 func ErrorOutput(format string, a ...interface{}) {
 	color.Red(format, a...)
+}
+
+// Bullet prints out the given message into stdout with a bulleted symbol at start
+func Bullet(format string, a ...interface{}) {
+	fmt.Println(fmt.Sprintf("• "+format, a...))
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -38,3 +38,11 @@ func TestInitColorOutput_True(t *testing.T) {
 		t.Fatalf("expected no-color to be set as true, but got %v", color.NoColor)
 	}
 }
+
+func ExampleBullet() {
+	arg := "foobar"
+
+	Bullet("setup %s", arg)
+
+	// Output: • setup foobar
+}

--- a/pkg/dunner/list_tasks.go
+++ b/pkg/dunner/list_tasks.go
@@ -3,6 +3,7 @@ package dunner
 import (
 	"fmt"
 
+	"github.com/leopardslab/dunner/internal/logger"
 	"github.com/leopardslab/dunner/pkg/config"
 	"github.com/spf13/viper"
 )
@@ -20,7 +21,7 @@ func ListTasks() error {
 	if len(errs) != 0 {
 		fmt.Println("Validation failed with following errors:")
 		for _, err := range errs {
-			fmt.Println(err.Error())
+			logger.ErrorOutput(err.Error())
 		}
 		return fmt.Errorf("validation failed")
 	}
@@ -30,7 +31,7 @@ func ListTasks() error {
 	} else {
 		fmt.Println("Available Dunner tasks:")
 		for taskName := range configs.Tasks {
-			fmt.Println(taskName)
+			logger.Bullet(taskName)
 		}
 		fmt.Println("Run `dunner do <task_name>` to run a dunner task.")
 	}

--- a/pkg/dunner/list_tasks_test.go
+++ b/pkg/dunner/list_tasks_test.go
@@ -37,6 +37,7 @@ build:
 
 	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
 	defer os.Remove(tmpFile.Name())
+	defer viper.Reset()
 
 	err := ListTasks()
 
@@ -65,6 +66,7 @@ build:
 
 	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
 	defer os.Remove(tmpFile.Name())
+	defer viper.Reset()
 
 	err := ListTasks()
 
@@ -73,12 +75,48 @@ build:
 	}
 }
 
+func ExampleListTasks_successWithAllTasksAsBullets() {
+	var tmpFilename = ".testdunner.yaml"
+	var content = []byte(`
+setup:
+  - image: node
+    command: []
+build:
+  - image: node
+    command: []`)
+
+	tmpFile, err := ioutil.TempFile("", tmpFilename)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := tmpFile.Write(content); err != nil {
+		panic(err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		panic(err)
+	}
+
+	viper.Set("DunnerTaskFile", tmpFile.Name())
+	defer viper.Reset()
+	defer os.Remove(tmpFile.Name())
+
+	ListTasks()
+
+	// Output: Available Dunner tasks:
+	// • setup
+	// • build
+	// Run `dunner do <task_name>` to run a dunner task.
+}
+
 func Test_ListTasksSuccessNoTasks(t *testing.T) {
 	var tmpFilename = ".testdunner.yaml"
 	var content = []byte("")
 
 	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
 	defer os.Remove(tmpFile.Name())
+	defer viper.Reset()
 
 	err := ListTasks()
 


### PR DESCRIPTION
Fixes #154
Previously:

```
Available Dunner tasks:
show
build
Run `dunner do <task_name>` to run a dunner task.
```

Now:

```
Available Dunner tasks:
• show
• build
Run `dunner do <task_name>` to run a dunner task.
```