### PR TITLE
Not throw validation errors on listing tasks

### DIFF
--- a/pkg/dunner/list_tasks.go
+++ b/pkg/dunner/list_tasks.go
@@ -16,15 +16,6 @@ func ListTasks() error {
 		return err
 	}
 
-	errs := configs.Validate()
-	if len(errs) != 0 {
-		fmt.Println("Validation failed with following errors:")
-		for _, err := range errs {
-			fmt.Println(err.Error())
-		}
-		return fmt.Errorf("validation failed")
-	}
-
 	if len(configs.Tasks) == 0 {
 		fmt.Println("No dunner tasks found")
 	} else {

--- a/pkg/dunner/list_tasks_test.go
+++ b/pkg/dunner/list_tasks_test.go
@@ -22,33 +22,6 @@ func Test_ListTasksWhenConfigFileNotFound(t *testing.T) {
 	}
 }
 
-func Test_ListTasksWhenValidationFails(t *testing.T) {
-	var tmpFilename = ".testdunner.yaml"
-	var content = []byte(`
-setup:
-  - image: node
-    commands:
-      - ["node", "--version"]
-      - ["npm", "--version"]
-    envs:
-      - MYVAR=MYVAL
-build:
-  - command: []`)
-
-	tmpFile := createDunnerTaskFile(t, content, tmpFilename)
-	defer os.Remove(tmpFile.Name())
-
-	err := ListTasks()
-
-	expected := "validation failed"
-	if err == nil {
-		t.Fatalf("got: %s, want: %s", err, expected)
-	}
-	if err.Error() != expected {
-		t.Fatalf("got: %s, want: %s", err.Error(), expected)
-	}
-}
-
 func Test_ListTasksSuccess(t *testing.T) {
 	var tmpFilename = ".testdunner.yaml"
 	var content = []byte(`

--- a/pkg/dunner/list_tasks_test.go
+++ b/pkg/dunner/list_tasks_test.go
@@ -55,12 +55,15 @@ tasks:
 func ExampleListTasks_successWithAllTasksAsBullets() {
 	var tmpFilename = ".testdunner.yaml"
 	var content = []byte(`
-setup:
-  - image: node
-    command: []
-build:
-  - image: node
-    command: []`)
+tasks:
+  setup:
+    steps:
+      - image: node
+        command: []
+  build:
+    steps:
+      - image: node
+        command: []`)
 
 	tmpFile, err := ioutil.TempFile("", tmpFilename)
 	if err != nil {


### PR DESCRIPTION
Fixes #156 

On `dunner tasks` no validation errors are shown. It will only be shown on `dunner do <task>`  or on `dunner validate`.