### PR TITLE
Fail git commit on errors | Use make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ifeq ($(VERSION),)
 VERSION := latest
 endif
 
+GO_FILES=$(ALL_PACKAGES)
+
 #Hooks
 PRECOMMIT_HOOK="./resources/git-hooks/pre-commit"
 
@@ -22,11 +24,12 @@ all: build test fmt lint vet
 
 setup: install hooks
 	@go get -u golang.org/x/lint/golint
+	@go get -u golang.org/x/tools/cmd/goimports
 
 hooks:
 	@cp $(PRECOMMIT_HOOK) ./.git/hooks/pre-commit
 
-install: 
+install:
 	@$(DEP) ensure -v
 
 build: install
@@ -45,7 +48,7 @@ fmt:
 	@go fmt $(ALL_PACKAGES)
 
 lint:
-	@golint -set_exit_status $(ALL_PACKAGES)
+	@golint -set_exit_status $(GO_FILES)
 
 precommit: build test fmt lint vet
 

--- a/resources/git-hooks/pre-commit
+++ b/resources/git-hooks/pre-commit
@@ -64,15 +64,21 @@ PASS=true
 for file in $gofiles
 do
   goimports -w $file
+  code=$(echo $?)
+  if [ $code != 0 ]; then
+    PASS=false
+  fi
 
-  golint "-set_exit_status" $file
-  if [ "$?" = 1 ]; then
+  make lint GO_FILES=$file
+  code=$(echo $?)
+  if [ $code != 0 ]; then
     PASS=false
   fi
 done
 
-go vet ./...
-if [ "$?" != 0 ]; then
+make vet
+code=$(echo $?)
+if [ $code != 0 ]; then
   PASS=false
 fi
 


### PR DESCRIPTION
Fixes #158 

* If there is a vet/lint/goimports error, git hooks should prevent git commit to succeed. 
* Use makefile commands in git hooks instead of using commands directly, so change is in one place when required.
* Install goimports as part of `make setup`