### PR TITLE
Parse environment variables referred in dunner step dir, name and mounts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -374,13 +374,27 @@ func obtainEnv(envVar string) (string, error) {
 	return envVar, nil
 }
 
-// ParseStepEnv parses Dir field of step and replaces environment variable with their values
+// ParseStepEnv parses Dir, Mounts, User fields of Step by replacing environment variables with their values
 func (step *Step) ParseStepEnv() error {
 	parsedDir, err := lookupDirectory(step.Dir)
 	if err != nil {
 		return err
 	}
 	step.Dir = parsedDir
+
+	for index, m := range step.Mounts {
+		parsedMount, err := lookupDirectory(m)
+		if err != nil {
+			return err
+		}
+		step.Mounts[index] = parsedMount
+	}
+
+	parsedUser, err := lookupDirectory(step.User)
+	if err != nil {
+		return err
+	}
+	step.User = parsedUser
 	return nil
 }
 
@@ -400,15 +414,7 @@ func DecodeMount(mounts []string, step *docker.Step) error {
 				readOnly = false
 			}
 		}
-		parsedSrcDir, err := lookupDirectory(arr[0])
-		if err != nil {
-			return err
-		}
-		parsedDestDir, err := lookupDirectory(arr[1])
-		if err != nil {
-			return err
-		}
-		src, err := filepath.Abs(joinPathRelToHome(parsedSrcDir))
+		src, err := filepath.Abs(joinPathRelToHome(arr[0]))
 		if err != nil {
 			return err
 		}
@@ -416,7 +422,7 @@ func DecodeMount(mounts []string, step *docker.Step) error {
 		(*step).ExtMounts = append((*step).ExtMounts, mount.Mount{
 			Type:     mount.TypeBind,
 			Source:   src,
-			Target:   parsedDestDir,
+			Target:   arr[1],
 			ReadOnly: readOnly,
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -440,7 +440,7 @@ func TestDecodeMount(t *testing.T) {
 
 func TestDecodeMountWithEnvironmentVariable(t *testing.T) {
 	step := &docker.Step{}
-	mounts := []string{"`$HOME`:`$HOME`"}
+	mounts := []string{"/tmp:/app"}
 
 	err := DecodeMount(mounts, step)
 
@@ -453,11 +453,34 @@ func TestDecodeMountWithEnvironmentVariable(t *testing.T) {
 	if len((*step).ExtMounts) != 1 {
 		t.Fatalf("expected ExtMounts to be of length 1, got %d", len((*step).ExtMounts))
 	}
-	if (*step).ExtMounts[0].Source != util.HomeDir {
-		t.Fatalf("expected ExtMounts Source to be %s, got %s", util.HomeDir, (*step).ExtMounts[0].Source)
+	if (*step).ExtMounts[0].Source != "/tmp" {
+		t.Fatalf("expected ExtMounts Source to be '/tmp', got %s", (*step).ExtMounts[0].Source)
 	}
-	if (*step).ExtMounts[0].Target != util.HomeDir {
-		t.Fatalf("expected ExtMounts Source to be %s, got %s", util.HomeDir, (*step).ExtMounts[0].Target)
+	if (*step).ExtMounts[0].Target != "/app" {
+		t.Fatalf("expected ExtMounts Source to be '/app', got %s", (*step).ExtMounts[0].Target)
+	}
+}
+
+func TestDecodeMountWithShorthandHomeDir(t *testing.T) {
+	step := &docker.Step{}
+	mounts := []string{"~/tmp:/app"}
+
+	err := DecodeMount(mounts, step)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err.Error())
+	}
+	if (*step).ExtMounts == nil {
+		t.Fatalf("expected ExtMounts to be set, got nil")
+	}
+	if len((*step).ExtMounts) != 1 {
+		t.Fatalf("expected ExtMounts to be of length 1, got %d", len((*step).ExtMounts))
+	}
+	if (*step).ExtMounts[0].Source != fmt.Sprintf("%s/tmp", util.HomeDir) {
+		t.Fatalf("expected ExtMounts Source to be '/tmp', got %s", (*step).ExtMounts[0].Source)
+	}
+	if (*step).ExtMounts[0].Target != "/app" {
+		t.Fatalf("expected ExtMounts Source to be '/app', got %s", (*step).ExtMounts[0].Target)
 	}
 }
 
@@ -564,5 +587,78 @@ func TestParseStepEnvToReplaceDirFailure(t *testing.T) {
 	}
 	if step.Dir != dir {
 		t.Errorf("expected step dir: %s, got: %s", dir, step.Dir)
+	}
+}
+
+func TestParseStepEnvToReplaceMountSuccess(t *testing.T) {
+	srcDir := "MY_ENVNAME"
+	os.Setenv(srcDir, "foobar")
+	destDir := "SUBDIR"
+	os.Setenv(destDir, "dunner")
+	defer os.Unsetenv(srcDir)
+	defer os.Unsetenv(destDir)
+	step := &Step{Image: "node", Mounts: []string{fmt.Sprintf("/tmp/`$%s`:/tmp/`$%s`/foo:w", srcDir, destDir)}}
+
+	err := step.ParseStepEnv()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+	expected := "/tmp/foobar:/tmp/dunner/foo:w"
+	if step.Mounts[0] != expected {
+		t.Errorf("expected step mount: %s, got: %s", expected, step.Mounts[0])
+	}
+}
+
+func TestParseStepEnvToReplaceMountFailure(t *testing.T) {
+	srcDir := "MY_ENVNAME"
+	os.Setenv(srcDir, "foobar")
+	defer os.Unsetenv(srcDir)
+	destDir := "SUBDIR"
+	os.Unsetenv(destDir)
+	mount := fmt.Sprintf("/tmp/`$%s`:/tmp/`$%s`/foo:w", srcDir, destDir)
+	step := &Step{Image: "node", Mounts: []string{mount}}
+
+	err := step.ParseStepEnv()
+
+	expectedErr := "could not find environment variable 'SUBDIR'"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("expected error %s, got %s", expectedErr, err)
+	}
+	if step.Mounts[0] != mount {
+		t.Errorf("expected step mount: %s, got: %s", mount, step.Mounts[0])
+	}
+}
+
+func TestParseStepEnvToReplaceUserFailure(t *testing.T) {
+	env := "UNSET_USER"
+	sErr := os.Unsetenv(env)
+	if sErr != nil {
+		t.Fatalf("failed to setup test environment: %s", sErr)
+	}
+	user := "`$UNSET_USER`"
+	step := &Step{Image: "node", User: user}
+
+	err := step.ParseStepEnv()
+
+	expectedErr := "could not find environment variable 'UNSET_USER'"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("expected error %s, got %s", expectedErr, err)
+	}
+	if step.User != user {
+		t.Errorf("expected step dir: %s, got: %s", user, step.User)
+	}
+}
+
+func TestParseStepEnvToReplaceUserSuccess(t *testing.T) {
+	step := &Step{Image: "node", User: "`$USER`"}
+
+	err := step.ParseStepEnv()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+	if step.User != os.Getenv("USER") {
+		t.Errorf("expected step dir: %s, got: %s", os.Getenv("USER"), step.User)
 	}
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -8,8 +8,8 @@ type Step struct {
 	// Image is the repo name on which Docker containers are built
 	Image string `yaml:"image" validate:"required_without=Follow"`
 
-	// SubDir is the primary directory on which task is to be run
-	SubDir string `yaml:"dir"`
+	// Dir is the primary directory on which task is to be run
+	Dir string `yaml:"dir"`
 
 	// The command which runs on the container and exits
 	Command []string `yaml:"command" validate:"omitempty,dive,required"`

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -63,7 +63,7 @@ func ExecTask(configs *config.Configs, taskName string, args []string) error {
 	for _, stepDefinition := range configs.Tasks[taskName].Steps {
 		err := stepDefinition.ParseStepEnv()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		if async {
 			wg.Add(1)

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -71,7 +71,7 @@ func ExecTask(configs *config.Configs, taskName string, args []string) error {
 			Command:  stepDefinition.Command,
 			Commands: stepDefinition.Commands,
 			Env:      stepDefinition.Envs,
-			WorkDir:  stepDefinition.SubDir,
+			WorkDir:  stepDefinition.Dir,
 			Follow:   stepDefinition.Follow,
 			Args:     stepDefinition.Args,
 			User:     getDunnerUser(stepDefinition),

--- a/pkg/dunner/dunner.go
+++ b/pkg/dunner/dunner.go
@@ -61,6 +61,10 @@ func ExecTask(configs *config.Configs, taskName string, args []string) error {
 		return fmt.Errorf("dunner: task '%s' does not exist", taskName)
 	}
 	for _, stepDefinition := range configs.Tasks[taskName].Steps {
+		err := stepDefinition.ParseStepEnv()
+		if err != nil {
+			log.Fatal(err)
+		}
 		if async {
 			wg.Add(1)
 		}

--- a/pkg/dunner/dunner_test.go
+++ b/pkg/dunner/dunner_test.go
@@ -118,6 +118,23 @@ func TestExecTask(t *testing.T) {
 	}
 }
 
+func TestExecTaskWithParseError(t *testing.T) {
+	step := config.Step{
+		Image: "busybox",
+		Dir:   "`$INVALID_USER_NONEXISTING`",
+	}
+	tasks := make(map[string]config.Task)
+	tasks["test"] = config.Task{Steps: []config.Step{step}}
+	configs := config.Configs{Tasks: tasks}
+
+	err := ExecTask(&configs, "test", []string{})
+
+	expectedErr := "could not find environment variable 'INVALID_USER_NONEXISTING'"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("expected error: %s, got %s", expectedErr, err)
+	}
+}
+
 func TestExecTaskAsync(t *testing.T) {
 	async := viper.GetBool("Async")
 	viper.Set("Async", true)


### PR DESCRIPTION
Fixes #142

If there are environment variables referred in step as below, all of them will be referenced from env.
```
status:
    steps:
      - image: golang:1.11-alpine3.8
        user: "`$NAME`"
        dir: "`$HOME`"
        commands:
          - ["ls", "-al"]
          - ["pwd"]
          - ["cat", "/tmp/hello.md"]
        mounts:
          - "/tmp/`$dir`:/tmp:r"

```